### PR TITLE
fix(build): publish web frontend assets so the CLI doesn't crash on launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "prepare": "husky",
     "build:frontend": "tsx src/bridges/user/web/build.ts",
-    "build": "pnpm build:frontend && tsc && printf '#!/usr/bin/env node\n' | cat - dist/cli.js > dist/cli.tmp && mv dist/cli.tmp dist/cli.js",
+    "build": "pnpm build:frontend && tsc && tsx scripts/copy-web-assets.ts && printf '#!/usr/bin/env node\n' | cat - dist/cli.js > dist/cli.tmp && mv dist/cli.tmp dist/cli.js",
     "generate:server-json": "tsx scripts/sync-release-metadata.ts",
     "publish:mcp-registry": "tsx scripts/publish-mcp-registry.ts",
     "lint": "eslint .",

--- a/scripts/copy-web-assets.ts
+++ b/scripts/copy-web-assets.ts
@@ -1,0 +1,35 @@
+/**
+ * Copy the built web frontend assets into the compiled output tree.
+ *
+ * `build:frontend` (esbuild) emits the bundles into
+ * `src/bridges/user/web/dist/`, and `index.html` lives alongside the frontend
+ * sources. `tsc` only emits JS/d.ts from `.ts` inputs, so these non-TS assets
+ * are never copied into the top-level `dist/`. Without this step the published
+ * package is missing `frontend/index.html`, `dist/bundle.js`, `dist/sw.js`,
+ * `dist/manifest.json` and `dist/icons/*`, and the web server crashes with
+ * ENOENT at module load — taking down every command, including setup. See #18.
+ *
+ * Usage: node/tsx scripts/copy-web-assets.ts (run after `tsc`)
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const webSrc = path.join(root, "src", "bridges", "user", "web");
+const webOut = path.join(root, "dist", "bridges", "user", "web");
+
+// Frontend shell (loaded by the server as INDEX_HTML). cpSync creates the
+// destination parent dir itself.
+fs.cpSync(
+  path.join(webSrc, "frontend", "index.html"),
+  path.join(webOut, "frontend", "index.html"),
+);
+
+// esbuild bundles + web app manifest + PWA icons.
+fs.cpSync(path.join(webSrc, "dist"), path.join(webOut, "dist"), {
+  recursive: true,
+});
+
+console.log(`Copied web assets to ${webOut}`);

--- a/src/bridges/user/web/build.ts
+++ b/src/bridges/user/web/build.ts
@@ -44,6 +44,10 @@ const inlineCssPlugin: esbuild.Plugin = {
 };
 
 async function main(): Promise<void> {
+  // Start from a clean output dir so stale artifacts (e.g. renamed bundles,
+  // leftover sourcemaps) can't linger and get swept into the published
+  // package by the copy-web-assets step.
+  fs.rmSync(DIST_DIR, { recursive: true, force: true });
   fs.mkdirSync(DIST_DIR, { recursive: true });
 
   await esbuild.build({


### PR DESCRIPTION
## Problem

`agent-comms@1.24.0` (current npm `latest`) crashes on **every** invocation — including bare `agent-comms` (setup) — before doing any work:

```
Error: ENOENT: no such file or directory, open '.../dist/bridges/user/web/frontend/index.html'
    at .../dist/bridges/user/web/server.js:30:23
```

## Root cause

`server.ts` reads its frontend assets from disk at module scope:

- `frontend/index.html`
- `dist/{bundle.js, sw.js, manifest.json, mesh-worker.js, relay-worker.js}`
- `dist/icons/*`

`index.html` is a static source file, and `build:frontend` (esbuild) emits the bundles into `src/bridges/user/web/dist/`. But `tsc` (`rootDir: src`, `outDir: dist`) only emits from `.ts` inputs, so **none of these non-TS assets are copied into the published `dist/` tree**. `"files": ["dist", …]` then ships a `dist/` missing them, and the top-level `readFileSync` throws at import — taking down the whole CLI.

`generated-html.ts` (an inlined `FRONTEND_HTML`) exists but is unused and stale (predates the current Preact frontend), so serving it is not the fix.

Full analysis in #18.

## Fix

- **`scripts/copy-web-assets.ts`** — after `tsc`, copy `frontend/index.html` and the esbuild output into `dist/bridges/user/web/`.
- **`package.json`** — wire that step into `build` (after `tsc`).
- **`build.ts`** — clean the esbuild output dir at the start of `build:frontend` so stale artifacts can't be swept into the package by the recursive copy.

## Verification

- `pnpm run build` produces all assets under `dist/bridges/user/web/`.
- `npm pack --dry-run` includes `frontend/index.html`, `dist/bundle.js`, `dist/sw.js`, `dist/manifest.json`, `dist/mesh-worker.js`, `dist/relay-worker.js`, and `dist/icons/*`.
- Installed the packed tarball into a clean prefix: `agent-comms` (setup) runs without crashing, and booting the web server serves `GET /` (the current Preact shell), `/bundle.js`, `/sw.js`, `/manifest.json`, `/icons/*`, and `/api/agents` — all `200` with correct content types.
- Clean-step check: a stray file planted in the esbuild output dir is wiped on rebuild and never reaches the tarball.

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)