### PR TITLE
fix(release): retry MCP registry publish on npm propagation lag

### DIFF
--- a/scripts/publish-mcp-registry.ts
+++ b/scripts/publish-mcp-registry.ts
@@ -10,6 +10,41 @@ function run(command: string, args: string[]): void {
   }
 }
 
+// The MCP registry validates a publish against the npm registry, where the version semantic-release published seconds earlier may not be visible yet. The registry's own error text says to wait and retry, so retry that failure specifically instead of failing the release job on propagation lag.
+const PUBLISH_RETRY_DELAYS_SECONDS = [15, 30, 60, 120];
+
+function isNpmPropagationLag(output: string): boolean {
+  return (
+    output.includes("was not found") &&
+    output.includes("A newly published release can take a moment")
+  );
+}
+
+function sleepSync(seconds: number): void {
+  spawnSync("sleep", [String(seconds)]);
+}
+
+function runPublishWithRetry(command: string, args: string[]): void {
+  for (let attempt = 1; ; attempt++) {
+    const result = spawnSync(command, args, { encoding: "utf8" });
+    if (result.status === 0) {
+      process.stdout.write(result.stdout);
+      return;
+    }
+    const output = `${result.stdout}${result.stderr}`;
+    const retryDelay = PUBLISH_RETRY_DELAYS_SECONDS[attempt - 1];
+    if (retryDelay !== undefined && isNpmPropagationLag(output)) {
+      console.error(
+        `mcp-publisher publish hit npm propagation lag (attempt ${String(attempt)}), retrying in ${String(retryDelay)}s`,
+      );
+      sleepSync(retryDelay);
+      continue;
+    }
+    process.stdout.write(output);
+    throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+  }
+}
+
 const os = process.platform;
 const arch = process.arch;
 
@@ -31,7 +66,7 @@ try {
     `curl -fsSL "${archiveUrl}" | tar -xzf - -C "${tempDir}" mcp-publisher`,
   ]);
   run(path.join(tempDir, "mcp-publisher"), ["login", "github-oidc"]);
-  run(path.join(tempDir, "mcp-publisher"), ["publish"]);
+  runPublishWithRetry(path.join(tempDir, "mcp-publisher"), ["publish"]);
 } finally {
   rmSync(tempDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
The v1.24.3 Release job failed: the MCP registry publish step ran seconds after semantic-release's npm publish, the registry's npm validation couldn't see version 1.24.3 yet, and it returned a 400 whose own error text says "A newly published release can take a moment to appear on the registry. Wait and retry".

Retry that specific failure with backoff (15s/30s/60s/120s) instead of failing the job; any other publish error still fails immediately. The npm package itself published fine — only the registry step raced.