### PR TITLE
feat(bridge): persist bridge identity across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sequenceDiagram
 
 ### Identity
 
-Each instance gets a unique peer ID on startup. Mesh state is in-memory; when a process exits, its peer is gone. Identity is not persisted because the mesh state dies with the process.
+Each bridge derives its peer ID from the fingerprint of its TLS certificate: ECDSA P-256, self-signed, generated locally. The key material persists per bridge slot (`~/.agent-comms/identity-<harness>--<cwd>.json`, owner-only permissions), so the fingerprint — and with it the agent ID, room memberships, and peers' ability to keep delivering to the agent — survives restarts. Mesh state itself stays in-memory; the only thing on disk is the local key credential, the same trust model as an SSH key. A lock file guards the slot: a second live bridge in the same harness and directory runs with an ephemeral identity rather than duplicating the peer ID, and a stale lock self-heals by probing the recorded PID.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "generate:server-json": "tsx scripts/sync-release-metadata.ts",
     "publish:mcp-registry": "tsx scripts/publish-mcp-registry.ts",
     "lint": "eslint .",
-    "test": "node --test dist/test/coordinator-socket-error.integration.test.js",
+    "test": "node --test dist/test/coordinator-socket-error.integration.test.js dist/test/identity-store.test.js",
     "test:visibility": "node --test dist/test/visibility.integration.test.js",
     "test:delivery": "node dist/test/delivery-receipt.runner.js",
     "test:all": "pnpm test && pnpm test:delivery",

--- a/src/bridges/claude-code/channel.ts
+++ b/src/bridges/claude-code/channel.ts
@@ -31,7 +31,11 @@ import {
   MCP_TOOL_PARAMS,
 } from "../../core/index.js";
 import { TlsTransport } from "../../core/tls-transport.js";
-import { generateIdentity } from "../../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  releaseIdentityLock,
+  type IdentitySlot,
+} from "../../core/identity-store.js";
 import { tryStartWebServer } from "../user/web/server.js";
 import { nanoid } from "../../core/nanoid.js";
 
@@ -151,7 +155,13 @@ function drainPending(filePath: string): string[] {
 }
 
 export async function run(): Promise<void> {
-  const identity = generateIdentity();
+  // Persistent identity for this slot: a stable fingerprint means the agent
+  // ID survives restarts, so peers can keep targeting us
+  const identitySlot: IdentitySlot = {
+    harness: "claude-code",
+    cwd: process.cwd(),
+  };
+  const identity = loadOrCreateIdentity(identitySlot);
   const store = new MeshStore();
   store.peerId = identity.fingerprint;
   store.setTransport(new TlsTransport(store.events, identity));
@@ -283,6 +293,8 @@ export async function run(): Promise<void> {
       await store.shutdown();
     } catch {
       // best-effort — the process is exiting anyway
+    } finally {
+      releaseIdentityLock(identitySlot);
     }
   }
 
@@ -296,5 +308,7 @@ export async function run(): Promise<void> {
     // Synchronous fallback if async shutdown didn't complete in time.
     // store.shutdown() is async but the coordinator socket unref() in
     // MeshStore.init() means the process won't hang on the way out.
+    // Lock release is synchronous and pid-guarded, so it is safe to repeat.
+    releaseIdentityLock(identitySlot);
   });
 }

--- a/src/bridges/codex/tool.ts
+++ b/src/bridges/codex/tool.ts
@@ -20,7 +20,10 @@ import {
   MCP_TOOL_PARAMS,
 } from "../../core/index.js";
 import { TlsTransport } from "../../core/tls-transport.js";
-import { generateIdentity } from "../../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  type IdentitySlot,
+} from "../../core/identity-store.js";
 import { tryStartWebServer } from "../user/web/server.js";
 import { nanoid } from "../../core/nanoid.js";
 
@@ -29,7 +32,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export async function run(): Promise<void> {
-  const identity = generateIdentity();
+  // Persistent identity for this slot: a stable fingerprint means the agent
+  // ID survives restarts, so peers can keep targeting us. The stdio server
+  // has no graceful shutdown hook; a stale lock self-heals via the pid probe.
+  const identitySlot: IdentitySlot = { harness: "codex", cwd: process.cwd() };
+  const identity = loadOrCreateIdentity(identitySlot);
   const store = new MeshStore();
   store.peerId = identity.fingerprint;
   store.setTransport(new TlsTransport(store.events, identity));

--- a/src/bridges/mcp/index.ts
+++ b/src/bridges/mcp/index.ts
@@ -20,7 +20,10 @@ import {
   MCP_TOOL_PARAMS,
 } from "../../core/index.js";
 import { TlsTransport } from "../../core/tls-transport.js";
-import { generateIdentity } from "../../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  type IdentitySlot,
+} from "../../core/identity-store.js";
 import { tryStartWebServer } from "../user/web/server.js";
 import { nanoid } from "../../core/nanoid.js";
 
@@ -29,7 +32,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export async function run(): Promise<void> {
-  const identity = generateIdentity();
+  // Persistent identity for this slot: a stable fingerprint means the agent
+  // ID survives restarts, so peers can keep targeting us. The stdio server
+  // has no graceful shutdown hook; a stale lock self-heals via the pid probe.
+  const identitySlot: IdentitySlot = { harness: "mcp", cwd: process.cwd() };
+  const identity = loadOrCreateIdentity(identitySlot);
   const store = new MeshStore();
   store.peerId = identity.fingerprint;
   store.setTransport(new TlsTransport(store.events, identity));

--- a/src/bridges/opencode/plugin.ts
+++ b/src/bridges/opencode/plugin.ts
@@ -14,11 +14,18 @@ import {
   formatDeliveryEvent,
 } from "../../core/index.js";
 import { TlsTransport } from "../../core/tls-transport.js";
-import { generateIdentity } from "../../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  type IdentitySlot,
+} from "../../core/identity-store.js";
 import { tryStartWebServer } from "../user/web/server.js";
 import { nanoid } from "../../core/nanoid.js";
 
-const identity = generateIdentity();
+// Persistent identity for this slot: a stable fingerprint means the agent
+// ID survives restarts, so peers can keep targeting us. A plugin unload has
+// no hook here; a stale lock self-heals via the pid probe.
+const identitySlot: IdentitySlot = { harness: "opencode", cwd: process.cwd() };
+const identity = loadOrCreateIdentity(identitySlot);
 const store = new MeshStore();
 store.peerId = identity.fingerprint;
 store.setTransport(new TlsTransport(store.events, identity));

--- a/src/bridges/pi/index.ts
+++ b/src/bridges/pi/index.ts
@@ -29,7 +29,11 @@ import {
   isActionableEvent,
 } from "../../core/index.js";
 import { TlsTransport } from "../../core/tls-transport.js";
-import { generateIdentity } from "../../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  releaseIdentityLock,
+  type IdentitySlot,
+} from "../../core/identity-store.js";
 import { tryStartWebServer, type WebServerHandle } from "../user/web/server.js";
 import { ChatController } from "../user/controller.js";
 import { nanoid } from "../../core/nanoid.js";
@@ -41,8 +45,10 @@ function getWebPort(handle: WebServerHandle): number | undefined {
 }
 
 export default function (pi: ExtensionAPI) {
-  // Generate cryptographic identity and use TLS transport
-  const identity = generateIdentity();
+  // Persistent identity for this slot: a stable fingerprint means the agent
+  // ID survives restarts, so peers can keep targeting us
+  const identitySlot: IdentitySlot = { harness: "pi", cwd: process.cwd() };
+  const identity = loadOrCreateIdentity(identitySlot);
   const store = new MeshStore();
   store.peerId = identity.fingerprint;
   store.setTransport(new TlsTransport(store.events, identity));
@@ -177,6 +183,7 @@ export default function (pi: ExtensionAPI) {
     if (agentId) {
       await store.setAgentOffline(agentId);
     }
+    releaseIdentityLock(identitySlot);
     await store.shutdown();
   });
 

--- a/src/bridges/user/controller.ts
+++ b/src/bridges/user/controller.ts
@@ -13,7 +13,11 @@ import {
   formatDeliveryEvent,
 } from "../../core/index.js";
 import { TlsTransport } from "../../core/tls-transport.js";
-import { generateIdentity } from "../../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  releaseIdentityLock,
+  type IdentitySlot,
+} from "../../core/identity-store.js";
 import type { CommsContext, CommsResult } from "../../core/tool.js";
 import type {
   AgentIdentity,
@@ -28,6 +32,8 @@ import type {
 
 export class ChatController extends EventEmitter {
   private store: MeshStore;
+  /** Set only when this controller owns its persisted identity (standalone mode). */
+  private ownedIdentitySlot: IdentitySlot | undefined;
 
   /** Expose the underlying MeshStore for handle cleanup. */
   get meshStore(): MeshStore {
@@ -42,7 +48,11 @@ export class ChatController extends EventEmitter {
     coordinatorPort?: number,
   ) {
     super();
-    const identity = generateIdentity();
+    // Persistent identity for the web user's slot so the chat identity
+    // survives relaunches of the standalone web CLI
+    const identitySlot: IdentitySlot = { harness: "user", cwd: process.cwd() };
+    this.ownedIdentitySlot = identitySlot;
+    const identity = loadOrCreateIdentity(identitySlot);
     this.store = new MeshStore(coordinatorPort);
     this.store.peerId = identity.fingerprint;
     this.store.setTransport(new TlsTransport(this.store.events, identity));
@@ -285,5 +295,8 @@ export class ChatController extends EventEmitter {
   async shutdown(): Promise<void> {
     await this.store.setAgentOffline(this.ctx.agentId);
     await this.store.shutdown();
+    if (this.ownedIdentitySlot !== undefined) {
+      releaseIdentityLock(this.ownedIdentitySlot);
+    }
   }
 }

--- a/src/core/identity-store.ts
+++ b/src/core/identity-store.ts
@@ -1,0 +1,171 @@
+/**
+ * Persistent bridge identity: load-or-create the TLS key material for a (harness, cwd) slot so the certificate fingerprint — and therefore the peer and agent ID — survives restarts.
+ *
+ * Mesh state stays in memory and on the wire; the only thing on disk is this local credential, the same trust model as an SSH key. A lock file holding a PID keeps two live bridges in one slot from sharing an identity, which would put duplicate peer IDs on the mesh; the second bridge runs with an ephemeral identity (the behaviour before persistence) instead. Bridges without a graceful shutdown hook can skip releasing the lock: a stale lock is detected by probing the recorded PID, the same way the coordinator probes for stale agents.
+ *
+ * Persisting the key material rather than a bare agent ID is what makes restarts work: delivery routing fires when agentId === peerId, and peerId is the live certificate fingerprint, so an ID without its key can never match the running peer.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  generateIdentity,
+  getCertificateFingerprint,
+  CERTIFICATE_VALIDITY_MS,
+} from "./identity.js";
+import type { PeerIdentity } from "./identity.js";
+
+/** A bridge's identity slot: one persisted identity per harness and cwd. */
+export interface IdentitySlot {
+  harness: string;
+  cwd: string;
+  /** Directory override for tests. */
+  dir?: string;
+}
+
+/** Renew during the final twelfth of the certificate's validity. */
+const RENEWAL_MARGIN_MS = CERTIFICATE_VALIDITY_MS / 12;
+
+interface StoredIdentity {
+  privateKey: string;
+  certificate: string;
+  expiresAt: string;
+}
+
+function isStoredIdentity(value: unknown): value is StoredIdentity {
+  if (typeof value !== "object" || value === null) return false;
+  if (
+    !("privateKey" in value) ||
+    !("certificate" in value) ||
+    !("expiresAt" in value)
+  )
+    return false;
+  return (
+    typeof value.privateKey === "string" &&
+    typeof value.certificate === "string" &&
+    typeof value.expiresAt === "string"
+  );
+}
+
+/** Replace path separators and other filesystem-hostile characters. */
+function slugifyCwd(cwd: string): string {
+  return cwd.replace(/[\\/:*?"<>|]/g, "_");
+}
+
+function slotPaths(slot: IdentitySlot): {
+  dir: string;
+  identityFile: string;
+  lockFile: string;
+} {
+  const dir = slot.dir ?? path.join(os.homedir(), ".agent-comms");
+  const base = `identity-${slot.harness}--${slugifyCwd(slot.cwd)}`;
+  return {
+    dir,
+    identityFile: path.join(dir, `${base}.json`),
+    lockFile: path.join(dir, `${base}.lock`),
+  };
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the PID holding the lock, or undefined when absent or unreadable. */
+function readLockPid(lockFile: string): number | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(lockFile, "utf-8");
+  } catch {
+    return undefined;
+  }
+  const pid = Number.parseInt(raw.trim(), 10);
+  return Number.isInteger(pid) ? pid : undefined;
+}
+
+function writeLock(lockFile: string): void {
+  fs.writeFileSync(lockFile, `${String(process.pid)}\n`, "utf-8");
+}
+
+function persistIdentity(identityFile: string, identity: PeerIdentity): void {
+  const stored: StoredIdentity = {
+    privateKey: identity.privateKey,
+    certificate: identity.certificate,
+    expiresAt: new Date(Date.now() + CERTIFICATE_VALIDITY_MS).toISOString(),
+  };
+  fs.writeFileSync(identityFile, `${JSON.stringify(stored, null, 2)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+}
+
+/**
+ * Load the persisted identity for the slot, creating it on first use, and take the slot lock. Returns an ephemeral identity when the slot is already held by another live process.
+ */
+export function loadOrCreateIdentity(slot: IdentitySlot): PeerIdentity {
+  const { dir, identityFile, lockFile } = slotPaths(slot);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const heldBy = readLockPid(lockFile);
+  if (heldBy !== undefined && heldBy !== process.pid && isPidAlive(heldBy)) {
+    console.error(
+      `agent-comms: identity slot ${slot.harness} (${slot.cwd}) is held by live pid ${String(heldBy)}; running with an ephemeral identity`,
+    );
+    return generateIdentity();
+  }
+
+  const identity =
+    loadStoredIdentity(identityFile) ?? createIdentity(identityFile);
+  writeLock(lockFile);
+  return identity;
+}
+
+/** Load and validate the stored key material, renewing near certificate expiry. */
+function loadStoredIdentity(identityFile: string): PeerIdentity | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(identityFile, "utf-8"));
+  } catch {
+    return undefined;
+  }
+  if (!isStoredIdentity(parsed)) return undefined;
+
+  const expiresAt = Date.parse(parsed.expiresAt);
+  if (Number.isNaN(expiresAt) || Date.now() > expiresAt - RENEWAL_MARGIN_MS) {
+    return undefined;
+  }
+
+  try {
+    return {
+      privateKey: parsed.privateKey,
+      certificate: parsed.certificate,
+      fingerprint: getCertificateFingerprint(parsed.certificate),
+    };
+  } catch (err) {
+    console.error(
+      `agent-comms: stored identity at ${identityFile} is unreadable (${err instanceof Error ? err.message : String(err)}); generating a fresh identity`,
+    );
+    return undefined;
+  }
+}
+
+function createIdentity(identityFile: string): PeerIdentity {
+  const identity = generateIdentity();
+  persistIdentity(identityFile, identity);
+  return identity;
+}
+
+/**
+ * Release the slot lock on graceful shutdown. A lock held by another PID (taken over after this process crashed and restarted) is left alone.
+ */
+export function releaseIdentityLock(slot: IdentitySlot): void {
+  const { lockFile } = slotPaths(slot);
+  if (readLockPid(lockFile) === process.pid) {
+    fs.rmSync(lockFile, { force: true });
+  }
+}

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -6,7 +6,9 @@
  * fingerprint of the certificate (DER-encoded, hex with colons), replacing
  * the previous nanoid(8) approach.
  *
- * Key material stays in memory only — never written to disk.
+ * Key material is generated in memory; bridges that need a stable identity
+ * across restarts persist it through identity-store.ts, which keeps the
+ * fingerprint (and therefore the peer/agent ID) stable.
  */
 
 import {
@@ -18,6 +20,9 @@ import {
 } from "node:crypto";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Self-signed certificate validity. Exported so identity persistence can derive its renewal margin. */
+export const CERTIFICATE_VALIDITY_MS = 365 * 24 * 60 * 60 * 1000;
 
 export interface PeerIdentity {
   /** PEM-encoded PKCS#8 private key. */
@@ -235,7 +240,9 @@ function buildExtensions(publicKeyDer: Buffer): Buffer {
  * Generate a fresh cryptographic identity: ECDSA P-256 keypair and self-signed
  * X.509 certificate. The fingerprint of the certificate serves as the peer ID.
  *
- * Key material stays in memory only — never written to disk.
+ * Key material is generated in memory; bridges that need a stable identity
+ * across restarts persist it through identity-store.ts, which keeps the
+ * fingerprint (and therefore the peer/agent ID) stable.
  */
 export function generateIdentity(): PeerIdentity {
   // When encoding options are specified, generateKeyPairSync returns
@@ -260,9 +267,9 @@ export function generateIdentity(): PeerIdentity {
   const firstSerialByte = serial[0];
   if (firstSerialByte !== undefined) serial[0] = firstSerialByte & 0x7f;
 
-  // Validity period: now through 365 days from now
+  // Validity period: now through CERTIFICATE_VALIDITY_MS from now
   const now = new Date();
-  const expires = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000);
+  const expires = new Date(now.getTime() + CERTIFICATE_VALIDITY_MS);
 
   // Subject/Issuer Name: SEQUENCE { SET { SEQUENCE { OID, value } } }
   const subject = derSequence(

--- a/src/test/identity-restart.integration.test.ts
+++ b/src/test/identity-restart.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration test for issue #14: a bridge restarted with a persisted identity must keep its agent ID, room membership, and push delivery.
+ *
+ * Before persistent identities, every restart generated a fresh TLS certificate, so the fingerprint-derived agent ID changed and peers kept targeting the old ID: their messages queued for an agent whose local handler (gated on agentId === peerId) never fired again.
+ */
+
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { MeshStore } from "../core/mesh-store.js";
+import { TlsTransport } from "../core/tls-transport.js";
+import { generateIdentity } from "../core/identity.js";
+import type { PeerIdentity } from "../core/identity.js";
+import {
+  loadOrCreateIdentity,
+  releaseIdentityLock,
+  type IdentitySlot,
+} from "../core/identity-store.js";
+import type { DeliveryEvent } from "../core/types.js";
+
+const TEST_PORT = 19889;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface Peer {
+  store: MeshStore;
+  deliveries: DeliveryEvent[];
+}
+
+/** A peer wired like a real bridge: TLS transport, fingerprint peer ID. */
+function makePeer(identity: PeerIdentity): Peer {
+  const store = new MeshStore(TEST_PORT);
+  store.peerId = identity.fingerprint;
+  store.setTransport(new TlsTransport(store.events, identity));
+  const deliveries: DeliveryEvent[] = [];
+  return { store, deliveries };
+}
+
+/** Poll until the predicate holds, or fail with the message. */
+async function waitFor(
+  what: string,
+  check: () => Promise<boolean>,
+): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (await check()) return;
+    await sleep(100);
+  }
+  assert.ok(false, `timed out waiting for ${what}`);
+}
+
+async function main(): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(tmpdir(), "agent-comms-restart-test-"));
+  const slot: IdentitySlot = { harness: "pi", cwd: "/tmp/project", dir };
+
+  // Peer B is a normal ephemeral bridge that stays up throughout.
+  const b = makePeer(generateIdentity());
+  await b.store.init();
+  // Registration must wait for the TLS data connections to establish:
+  // patches broadcast in between are silently lost (#23).
+  await sleep(300);
+  await b.store.registerAgent({
+    name: "peer-b",
+    harness: "claude-code",
+    cwd: "/tmp/b",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  b.store.onDelivery = (_id, ev) => {
+    b.deliveries.push(ev);
+  };
+  await sleep(200);
+
+  // First lifecycle of peer A: persistent identity, registers and creates a room.
+  const identityA = loadOrCreateIdentity(slot);
+  const a1 = makePeer(identityA);
+  await a1.store.init();
+  await sleep(300);
+  await a1.store.registerAgent({
+    name: "peer-a",
+    harness: "pi",
+    cwd: "/tmp/project",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  const roomId = "restart-continuity";
+  await a1.store.createRoom({
+    name: roomId,
+    type: "public",
+    owner: a1.store.peerId,
+    description: "issue 14 acceptance",
+  });
+  await sleep(200);
+  await b.store.joinRoom(roomId, b.store.peerId);
+  await sleep(200);
+  const agentIdA = a1.store.peerId;
+
+  // A goes away without marking its agent offline (crash simulation).
+  await a1.store.shutdown();
+  await sleep(200);
+
+  // A restarts in the same slot: same key material, same agent ID.
+  const identityA2 = loadOrCreateIdentity(slot);
+  assert.equal(identityA2.fingerprint, identityA.fingerprint);
+  const a2 = makePeer(identityA2);
+  a2.store.onDelivery = (_id, ev) => {
+    a2.deliveries.push(ev);
+  };
+  await a2.store.init();
+  await sleep(300);
+  await a2.store.registerAgent({
+    name: "peer-a",
+    harness: "pi",
+    cwd: "/tmp/project",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+
+  assert.equal(a2.store.peerId, agentIdA);
+  await waitFor("B to see the restarted agent active", async () => {
+    const agents = await b.store.listAgents(b.store.peerId);
+    const seen = agents.find((agent) => agent.id === agentIdA);
+    return seen?.status === "active";
+  });
+
+  // Room membership survived: B's message must push to restarted A.
+  await b.store.sendRoomMessage(roomId, b.store.peerId, "after restart");
+  await waitFor("the room message to push to restarted A", async () =>
+    a2.deliveries.some(
+      (ev) =>
+        ev.type === "room_message" && ev.message.content === "after restart",
+    ),
+  );
+
+  // DMs targeted at the persisted ID must deliver too.
+  await b.store.sendDm(b.store.peerId, agentIdA, "dm after restart");
+  await waitFor("the DM to push to restarted A", async () =>
+    a2.deliveries.some(
+      (ev) => ev.type === "dm" && ev.message.content === "dm after restart",
+    ),
+  );
+
+  await a2.store.shutdown();
+  await b.store.shutdown();
+  releaseIdentityLock(slot);
+  console.log(
+    "✓ restart continuity holds: same ID, active, room + DM delivered",
+  );
+}
+
+main().catch((err: unknown) => {
+  console.error("Test failed:", err);
+  process.exitCode = 1;
+  // The sequence above keeps mesh handles open when it fails partway; exit explicitly so a failure cannot hang the runner.
+  process.exit(1);
+});

--- a/src/test/identity-store.test.ts
+++ b/src/test/identity-store.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for persistent bridge identity (core/identity-store).
+ */
+
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { test } from "node:test";
+import {
+  loadOrCreateIdentity,
+  releaseIdentityLock,
+  type IdentitySlot,
+} from "../core/identity-store.js";
+
+function tempSlot(harness: string): { slot: IdentitySlot; dir: string } {
+  const dir = fs.mkdtempSync(path.join(tmpdir(), "agent-comms-identity-test-"));
+  return { slot: { harness, cwd: "/tmp/project", dir }, dir };
+}
+
+function slotFile(dir: string, suffix: string): string {
+  const found = fs.readdirSync(dir).find((f) => f.endsWith(suffix));
+  assert.ok(found !== undefined, `expected a ${suffix} file in ${dir}`);
+  return path.join(dir, found);
+}
+
+function lockPid(lockFile: string): number {
+  return Number.parseInt(fs.readFileSync(lockFile, "utf-8").trim(), 10);
+}
+
+/** A child process that stays alive until killed, for live-PID lock tests. */
+function spawnLiveProcess(): { pid: number; exit: () => Promise<void> } {
+  const child = spawn(
+    process.execPath,
+    ["-e", "setInterval(() => {}, 60000)"],
+    { stdio: "ignore" },
+  );
+  assert.ok(child.pid !== undefined);
+  return {
+    pid: child.pid,
+    exit: () =>
+      new Promise((resolve) => {
+        child.kill("SIGKILL");
+        child.on("exit", () => resolve());
+      }),
+  };
+}
+
+void test("loadOrCreateIdentity persists and reloads the same key material", () => {
+  const { slot, dir } = tempSlot("pi");
+  const first = loadOrCreateIdentity(slot);
+  const lockFile = slotFile(dir, ".lock");
+  assert.equal(lockPid(lockFile), process.pid);
+
+  const reloaded = loadOrCreateIdentity(slot);
+  assert.equal(reloaded.fingerprint, first.fingerprint);
+  assert.equal(reloaded.privateKey, first.privateKey);
+  assert.equal(reloaded.certificate, first.certificate);
+
+  releaseIdentityLock(slot);
+  assert.equal(fs.existsSync(lockFile), false);
+});
+
+void test("identity file is created with owner-only permissions", () => {
+  const { slot, dir } = tempSlot("claude-code");
+  loadOrCreateIdentity(slot);
+  const mode = fs.statSync(slotFile(dir, ".json")).mode & 0o777;
+  assert.equal(mode, 0o600);
+  releaseIdentityLock(slot);
+});
+
+void test("a slot held by a live process yields an ephemeral identity", () => {
+  const { slot, dir } = tempSlot("mcp");
+  const owner = loadOrCreateIdentity(slot);
+  const lockFile = slotFile(dir, ".lock");
+
+  const holder = spawnLiveProcess();
+  fs.writeFileSync(lockFile, `${String(holder.pid)}\n`);
+
+  const loser = loadOrCreateIdentity(slot);
+  assert.notEqual(loser.fingerprint, owner.fingerprint);
+  // The live holder's lock must not be clobbered by the ephemeral loser.
+  assert.equal(lockPid(lockFile), holder.pid);
+
+  void holder.exit();
+  releaseIdentityLock(slot);
+});
+
+void test("a stale lock from a dead process is taken over", async () => {
+  const { slot, dir } = tempSlot("codex");
+  const owner = loadOrCreateIdentity(slot);
+  const lockFile = slotFile(dir, ".lock");
+
+  const holder = spawnLiveProcess();
+  fs.writeFileSync(lockFile, `${String(holder.pid)}\n`);
+  await holder.exit();
+
+  const successor = loadOrCreateIdentity(slot);
+  assert.equal(successor.fingerprint, owner.fingerprint);
+  releaseIdentityLock(slot);
+});
+
+void test("a near-expiry identity is renewed", () => {
+  const { slot, dir } = tempSlot("opencode");
+  const original = loadOrCreateIdentity(slot);
+
+  const identityFile = slotFile(dir, ".json");
+  const stored = JSON.parse(fs.readFileSync(identityFile, "utf-8")) as {
+    expiresAt: string;
+  };
+  stored.expiresAt = new Date(Date.now() + 1000).toISOString();
+  fs.writeFileSync(identityFile, JSON.stringify(stored));
+
+  const renewed = loadOrCreateIdentity(slot);
+  assert.notEqual(renewed.fingerprint, original.fingerprint);
+  releaseIdentityLock(slot);
+});
+
+void test("a corrupt identity file is regenerated", () => {
+  const { slot, dir } = tempSlot("user");
+  loadOrCreateIdentity(slot);
+  fs.writeFileSync(slotFile(dir, ".json"), "{not json");
+
+  const regenerated = loadOrCreateIdentity(slot);
+  assert.match(regenerated.fingerprint, /^[0-9A-F]{2}(:[0-9A-F]{2})+$/);
+  releaseIdentityLock(slot);
+});


### PR DESCRIPTION
Fixes #14.

Every bridge restart used to generate a fresh TLS certificate, so the fingerprint-derived agent ID changed. Peers kept targeting the old ID; messages queued for an agent whose local delivery handler (gated on `agentId === peerId`) never fired again — exactly the silent delivery loss in #14.

This persists the **key material** per bridge slot (`~/.agent-comms/identity-<harness>--<cwd>.json`, 0600), so the fingerprint — and with it the agent ID, room memberships, and peers' ability to keep delivering — survives restarts. The mesh itself stays in-memory; the disk holds only the local key credential, the same trust model as an SSH key.

- A PID lock file guards each slot: a second live bridge in the same harness and cwd runs with an ephemeral identity (the previous behaviour) rather than duplicating a peer ID; a stale lock self-heals via the same signal-0 probe the coordinator uses for stale agents.
- Certificates renew during the final twelfth of their validity.
- Federation link identities stay ephemeral (scoped to a link lifecycle, not a bridge restart).
- Identity-store unit tests run in CI (`pnpm test`); a restart-continuity integration test proves the #14 acceptance path end-to-end (same ID, agent active again from a peer's view, room message and DM pushed to the restarted bridge).

Note: persisting a bare agent ID (as #15 proposed) cannot work — `peerId` is the live certificate fingerprint and TLS verification pins IDs to fingerprints, so an ID decoupled from its key breaks both the delivery gate and the self-certifying identity model. #15 is superseded by this.

While writing the acceptance test I also traced a separate, pre-existing race and filed it as #23: state patches broadcast before the TLS data connections establish are silently lost, which affects immediate post-`init()` registration generally.