### PR TITLE
test(core): wire the mesh integration suites into CI and cover the ws queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "generate:server-json": "tsx scripts/sync-release-metadata.ts",
     "publish:mcp-registry": "tsx scripts/publish-mcp-registry.ts",
     "lint": "eslint .",
-    "test": "node --test dist/test/coordinator-socket-error.integration.test.js dist/test/identity-store.test.js dist/test/identity-cert.test.js",
+    "test": "node --test --test-concurrency=1 dist/test/coordinator-socket-error.integration.test.js dist/test/identity-store.test.js dist/test/identity-cert.test.js dist/test/broadcast-window.integration.test.js dist/test/identity-restart.integration.test.js dist/test/mesh-e2e.integration.test.js dist/test/ws-broadcast-window.integration.test.js dist/test/tls-transport.integration.test.js",
     "test:visibility": "node --test dist/test/visibility.integration.test.js",
     "test:delivery": "node dist/test/delivery-receipt.runner.js",
     "test:all": "pnpm test && pnpm test:delivery",

--- a/src/test/tls-transport.integration.test.ts
+++ b/src/test/tls-transport.integration.test.ts
@@ -2,7 +2,8 @@
  * TlsTransport integration test — verifies that two MeshStore instances
  * can communicate over TLS with certificate pinning.
  *
- * Run: node dist/test/tls-transport.integration.test.js
+ * Run: node dist/test/tls-transport.integration.test.js [test-name]
+ * With no argument, every scenario runs in order.
  */
 
 import * as net from "node:net";
@@ -156,38 +157,42 @@ async function testFingerprintIsPeerId(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const testName = process.argv[2];
-if (testName === undefined) {
-  console.error("Usage: node tls-transport.integration.test.ts <test-name>");
-  process.exit(1);
-}
 
 const tests: Record<string, () => Promise<void>> = {
   "tls-communication": testTlsPeerCommunication,
   "tls-fingerprint": testFingerprintIsPeerId,
 };
 
-const fn = tests[testName];
-if (!fn) {
+const selected =
+  testName === undefined
+    ? Object.entries(tests)
+    : Object.entries(tests).filter(([name]) => name === testName);
+if (selected.length === 0) {
   console.error(`Unknown test: ${testName}`);
   console.error(`Available: ${Object.keys(tests).join(", ")}`);
   process.exit(1);
 }
 
-fn()
-  .then(async () => {
-    const maxWait = 2000;
-    const start = Date.now();
-    while (
-      ((
-        process as unknown as { _getActiveHandles?: () => unknown[] }
-      )._getActiveHandles?.()?.length ?? 0) > 0 &&
-      Date.now() - start < maxWait
-    ) {
-      await new Promise<void>((resolve) => setTimeout(resolve, 50));
-    }
-    process.exit(0);
-  })
-  .catch((err: unknown) => {
-    console.error(`FAIL [${testName}]:`, err);
-    process.exit(1);
-  });
+async function run(): Promise<void> {
+  for (const [name, fn] of selected) {
+    console.log(`Running ${name}:`);
+    await fn();
+  }
+
+  const maxWait = 2000;
+  const start = Date.now();
+  while (
+    ((
+      process as unknown as { _getActiveHandles?: () => unknown[] }
+    )._getActiveHandles?.()?.length ?? 0) > 0 &&
+    Date.now() - start < maxWait
+  ) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  process.exit(0);
+}
+
+run().catch((err: unknown) => {
+  console.error(`FAIL [${testName ?? "all"}]:`, err);
+  process.exit(1);
+});

--- a/src/test/ws-broadcast-window.integration.test.ts
+++ b/src/test/ws-broadcast-window.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration test for the WebSocket transport's broadcast queue: state patches broadcast before the WS data connections are established must be queued and flushed on registration, not dropped (#23).
+ *
+ * Mirrors broadcast-window.integration.test.ts over TlsTransport; the queue logic is implemented per transport, so each needs its own coverage.
+ */
+
+import * as assert from "node:assert/strict";
+import { MeshStore } from "../core/mesh-store.js";
+import { WebSocketTransport } from "../core/ws-transport.js";
+
+const TEST_PORT = 19892;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** A peer wired like a WS-based participant (browser relay worker). */
+function makePeer(): MeshStore {
+  const store = new MeshStore(TEST_PORT);
+  store.setTransport(new WebSocketTransport(store.events));
+  return store;
+}
+
+/** Poll until the predicate holds, or fail with the message. */
+async function waitFor(
+  what: string,
+  check: () => Promise<boolean>,
+): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (await check()) return;
+    await sleep(100);
+  }
+  assert.ok(false, `timed out waiting for ${what}`);
+}
+
+async function main(): Promise<void> {
+  // A is the coordinator and stays up throughout.
+  const a = makePeer();
+  await a.init();
+  await a.registerAgent({
+    name: "peer-a",
+    harness: "user",
+    cwd: "/test/a",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+
+  // B joins and registers IMMEDIATELY after init() — no settle delay. This is exactly the pattern that used to race the dials and lose the upsert.
+  const b = makePeer();
+  await b.init();
+  await b.registerAgent({
+    name: "peer-b",
+    harness: "user",
+    cwd: "/test/b",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  const bId = b.peerId;
+
+  await waitFor(
+    "the coordinator to see the immediately-registered agent",
+    async () => {
+      const agents = await a.listAgents(a.peerId);
+      const seen = agents.find((agent) => agent.id === bId);
+      return seen?.status === "active";
+    },
+  );
+
+  await waitFor("the joining peer to see the coordinator's agent", async () => {
+    const agents = await b.listAgents(b.peerId);
+    return agents.some((agent) => agent.id === a.peerId);
+  });
+
+  // A room message from the coordinator must push to the joiner over WS.
+  await a.createRoom({
+    name: "ws-window",
+    type: "public",
+    owner: a.peerId,
+    description: "ws broadcast window",
+  });
+  await waitFor("the room to reach the joiner", async () => {
+    const rooms = await b.listRooms(b.peerId);
+    return rooms.some((room) => room.id === "ws-window");
+  });
+  await b.joinRoom("ws-window", b.peerId);
+  // Wait for the membership to reach the sender before sending: delivery is
+  // computed from the sender's local room state.
+  await waitFor("the coordinator to see the joiner in the room", async () => {
+    const room = await a.getRoom("ws-window");
+    return room?.members.includes(bId) === true;
+  });
+  const deliveries: string[] = [];
+  b.onDelivery = (_id, ev) => {
+    if (ev.type === "room_message") deliveries.push(ev.message.content);
+  };
+  await a.sendRoomMessage("ws-window", a.peerId, "hello over ws");
+  await waitFor("the WS room message push", async () =>
+    deliveries.includes("hello over ws"),
+  );
+
+  await b.shutdown();
+  await a.shutdown();
+  console.log("✓ immediate registration and delivery work over WebSocket");
+}
+
+main().catch((err: unknown) => {
+  console.error("Test failed:", err);
+  process.exitCode = 1;
+  // The sequence above keeps mesh handles open when it fails partway; exit explicitly so a failure cannot hang the runner.
+  process.exit(1);
+});


### PR DESCRIPTION
Resolves items 3, 4, and 5 of the deferred follow-ups from the #23/#24 sessions.

`pnpm test` ran only three suites (coordinator socket-error, identity-store, identity-cert); every mesh integration suite ran ad hoc, so the cross-visibility and broadcast-queue regressions they pin — including the exact #23 repro — were invisible to CI. All of them now run in one serial `node --test --test-concurrency=1` invocation, so concurrent meshes cannot contend for CPU on shared runners:

- `broadcast-window` (the #23 repro), `identity-restart` (the #14 acceptance path), `mesh-e2e` (which also gives the TCP transport's queue path its first real coverage), and `ws-broadcast-window` — new, covering the WebSocket queue path, which had no coverage at all (two WS peers, immediate post-init registration, room-message push, with the membership-convergence wait the sender needs before delivery is meaningful).
- `tls-transport` now runs too, since this PR also makes its runner execute all scenarios when invoked without a name (previously: usage message and exit; named selection unchanged).

Full wired suite: 13 tests, five consecutive clean local rounds plus lint/typecheck/build green.