### PR TITLE
fix(mesh-store): replay only delivery events that carry consumption evidence

### DIFF
--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -373,9 +373,24 @@ export class MeshStore implements CommsStore {
         for (const event of events) {
           if (seen.has(JSON.stringify(event))) continue;
           this.queueDelivery(agentId, event);
-          // A returning peer replays its own pending queue: events pushed
-          // while its process was down fire onDelivery now (#28).
-          this.fireLocalDelivery(agentId, event);
+          // Replay fires only for events with consumption evidence (#28):
+          // messages are consumed by reading (readBy), invites by acceptance
+          // or decline (no longer in the invited list). Transient
+          // notifications (member_joined, room_members, connection_request,
+          // delivery status) carry no consumption evidence, so replaying
+          // them could only ever duplicate-notify; the state they describe
+          // arrives via the synced room and agent records instead. They
+          // still merge into the queue, so drain bridges see them.
+          if (event.type === "room_message" || event.type === "dm") {
+            this.fireLocalDelivery(agentId, event);
+          } else if (event.type === "room_invite") {
+            const stillInvited = this.rooms
+              .get(event.room)
+              ?.invited.includes(agentId);
+            if (stillInvited === true) {
+              this.fireLocalDelivery(agentId, event);
+            }
+          }
         }
       }
     }

--- a/src/test/downtime-replay.test.ts
+++ b/src/test/downtime-replay.test.ts
@@ -70,8 +70,15 @@ void test("events queued while the target was down replay on its first snapshot"
     true,
   );
 
-  // A second snapshot of the same state does not duplicate any push (the
-  // join notification replays too, exactly once).
+  // Transient notifications carry no consumption evidence, so they merge into the queue (drain bridges still see them) but never replay-fire.
+  assert.equal(deliveries.filter((ev) => ev.type === "room_members").length, 0);
+  const queue = snapshotOf(returned).deliveryQueues[targetAgent.id] ?? [];
+  assert.equal(
+    queue.some((ev) => ev.type === "room_members"),
+    true,
+  );
+
+  // A second snapshot of the same state does not duplicate the push.
   returned.applyStateSync(snapshotOf(sender));
   assert.equal(
     deliveries.filter(
@@ -81,7 +88,6 @@ void test("events queued while the target was down replay on its first snapshot"
     ).length,
     1,
   );
-  assert.equal(deliveries.filter((ev) => ev.type === "room_members").length, 1);
 });
 
 void test("a queue is bounded oldest-first so downtime cannot grow it without limit", async () => {
@@ -122,4 +128,55 @@ void test("a queue is bounded oldest-first so downtime cannot grow it without li
       queued[0].message.content === "msg-20",
     true,
   );
+});
+
+void test("a pending invite replays until accepted or declined", async () => {
+  const sender = makeStore();
+  const author = await sender.registerAgent({
+    name: "owner",
+    harness: "pi",
+    cwd: "/tmp/p",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  const target = makeStore();
+  const targetAgent = await target.registerAgent({
+    name: "invitee",
+    harness: "claude-code",
+    cwd: "/tmp/t",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  sender.applyStateSync(target.serialise());
+  await sender.createRoom({
+    name: "private-room",
+    type: "private",
+    owner: author.id,
+    description: "x",
+  });
+  await sender.inviteToRoom("private-room", targetAgent.id, author.id);
+
+  const returned = makeStore();
+  const deliveries: DeliveryEvent[] = [];
+  returned.onDelivery = (_id, ev) => {
+    deliveries.push(ev);
+  };
+  returned.peerId = targetAgent.id;
+
+  // Still on the invited list: the invite replays.
+  returned.applyStateSync(snapshotOf(sender));
+  assert.equal(deliveries.filter((ev) => ev.type === "room_invite").length, 1);
+
+  // Declined (no longer invited): the same snapshot no longer replays it.
+  await sender.declineInvite("private-room", targetAgent.id, "not now");
+  const declined = makeStore();
+  const deliveries2: DeliveryEvent[] = [];
+  declined.onDelivery = (_id, ev) => {
+    deliveries2.push(ev);
+  };
+  declined.peerId = targetAgent.id;
+  declined.applyStateSync(snapshotOf(sender));
+  assert.equal(deliveries2.filter((ev) => ev.type === "room_invite").length, 0);
 });


### PR DESCRIPTION
Follow-up to #30, closing the replay re-fire boundary documented on #28 exactly rather than bounding it.

Replay fired for every merged queue event, but transient notifications (`room_members`, `member_joined`, `connection_request`, delivery status) have no consumption evidence — replaying them could only duplicate-notify, and the structural-key LRU's eviction window admitted occasional re-fires for them. Replay now fires only for events whose consumption is observable:

- **room messages and DMs** — `readBy` carries the reader;
- **room invites** — the invited list carries pending-ness (accepted or declined removes it).

Transient notifications still merge into the queue (drain bridges see them), and the state they describe arrives through the synced room and agent records — a returning bridge that cared about current membership reads the converged state rather than replaying a stale ping.

Tests cover: the invite replay-while-pending / no-replay-after-decline pair, and transient notification queue-merge-without-fire. Full suite 21 tests green, lint/typecheck/build clean.