### PR TITLE
docs: mark the identity migration as a breaking change (agent-comms v2)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-node node_modules/.bin/eslint . 2>&1 && node node_modules/.bin/tsc --noEmit 2>&1 && node node_modules/.bin/tsx src/bridges/user/web/build.ts 2>&1 && printf '#!/usr/bin/env node\n' | cat - dist/cli.js > dist/cli.tmp && mv dist/cli.tmp dist/cli.js && node --test dist/test/coordinator-socket-error.integration.test.js 2>&1
+node node_modules/.bin/eslint . 2>&1 && node node_modules/.bin/tsc --noEmit 2>&1 && node node_modules/.bin/tsx --test --test-concurrency=1 'src/test/**/*.test.ts' 2>&1

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ sequenceDiagram
 
 ### Identity
 
-Each bridge derives its peer ID from the fingerprint of its TLS certificate: ECDSA P-256, self-signed, generated locally. The key material persists per bridge slot (`~/.agent-comms/identity-<harness>--<cwd>.json`, owner-only permissions), so the fingerprint — and with it the agent ID, room memberships, and peers' ability to keep delivering to the agent — survives restarts. Mesh state itself stays in-memory; the only thing on disk is the local key credential, the same trust model as an SSH key. A lock file guards the slot: a second live bridge in the same harness and directory runs with an ephemeral identity rather than duplicating the peer ID, and a stale lock self-heals by probing the recorded PID.
+Each bridge derives its peer ID from the device-id of its own keypair (SHA-256 of the raw public key): ECDSA P-256, self-signed, generated locally. The key material persists per bridge slot (`~/.agent-comms/identity-<harness>--<cwd>.json`, owner-only permissions), so the device-id — and with it the agent ID, room memberships, and peers' ability to keep delivering to the agent — survives restarts. Mesh state itself stays in-memory; the only thing on disk is the local key credential, the same trust model as an SSH key. A lock file guards the slot: a second live bridge in the same harness and directory runs with an ephemeral identity rather than duplicating the peer ID, and a stale lock self-heals by probing the recorded PID.
+
+**Breaking change (v2):** earlier versions derived the peer ID from the SHA-256 fingerprint of the peer's self-signed X.509 certificate rather than its raw public key. The two values differ for the same keypair, so every agent ID, room membership, and pending delivery queue tied to a pre-v2 identity is orphaned on upgrade — there is no migration path, since existing peers can no longer address an upgraded one under its old ID. A v2 bridge cannot interoperate with a v1 one at all: they no longer agree on wire framing, transport, or peer identity.
 
 ## Install
 


### PR DESCRIPTION
Step 7 of #47's sequencing ("ship as agent-comms-v2"). The peer-id derivation change (certificate fingerprint -> device-id) that landed across #58-#61 is a genuine breaking change -- every existing agent-comms identity/agent-id is orphaned on upgrade, no migration path -- but none of those commits carried a `BREAKING CHANGE:` footer, so semantic-release has been publishing them as ordinary patch/minor bumps (now v1.33.1) instead of a major version.

Two commits:
1. Corrects the README's Identity section, which still described the retired fingerprint-based derivation, and adds a BREAKING CHANGE footer describing the actual break -- this is what tells semantic-release's next run to cut v2.0.0.
2. An unrelated stale artifact found while pushing this: `.husky/pre-push` still ran a partial manual build assuming `dist/cli.js` already existed from an earlier full build, then executed one hardcoded compiled test file (`dist/test/coordinator-socket-error.integration.test.js`) -- both left over from before the test suite moved to running directly against source via tsx. Failed outright on a fresh checkout with no prior `dist/`. Now runs lint, typecheck, and the real `pnpm test` suite directly.