### PR TITLE
build: depend on the real published wire-mesh-core npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
     "typescript-eslint": "8.69.0"
   },
   "dependencies": {
-    "@exadev/wire-mesh-core": "github:ExaDev/wire-mesh#path:ts/packages/core",
     "@modelcontextprotocol/sdk": "1.30.0",
     "cbor2": "2.3.0",
     "preact": "10.29.7",
     "typebox": "1.3.6",
+    "wire-mesh-core": "1.0.1",
     "ws": "8.21.1",
     "zod": "4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
 
   .:
     dependencies:
-      '@exadev/wire-mesh-core':
-        specifier: github:ExaDev/wire-mesh#path:ts/packages/core
-        version: https://codeload.github.com/ExaDev/wire-mesh/tar.gz/e2b984fcb29b102868b38eef8f45afe7b0a2118f#path:ts/packages/core
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
         version: 1.30.0(zod@4.4.3)
@@ -38,6 +35,9 @@ importers:
       typebox:
         specifier: 1.3.6
         version: 1.3.6
+      wire-mesh-core:
+        specifier: 1.0.1
+        version: 1.0.1
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -542,10 +542,6 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@exadev/wire-mesh-core@https://codeload.github.com/ExaDev/wire-mesh/tar.gz/e2b984fcb29b102868b38eef8f45afe7b0a2118f#path:ts/packages/core':
-    resolution: {path: ts/packages/core, tarball: https://codeload.github.com/ExaDev/wire-mesh/tar.gz/e2b984fcb29b102868b38eef8f45afe7b0a2118f}
-    version: 0.0.0
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -3239,6 +3235,9 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wire-mesh-core@1.0.1:
+    resolution: {integrity: sha512-dYA5O6j3/+uv9zta8tXrqZq0o0+JEb1gMIzELPjHJmqQtG33a7QeE2aszsYgHbpieOX6FU8INryU8gej6g2ZyA==}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -3794,12 +3793,6 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
-
-  '@exadev/wire-mesh-core@https://codeload.github.com/ExaDev/wire-mesh/tar.gz/e2b984fcb29b102868b38eef8f45afe7b0a2118f#path:ts/packages/core':
-    dependencies:
-      cbor2: 2.3.0
-      cddl.js: 1.0.1
-      zod: 4.5.4
 
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))':
     dependencies:
@@ -6786,6 +6779,12 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wire-mesh-core@1.0.1:
+    dependencies:
+      cbor2: 2.3.0
+      cddl.js: 1.0.1
+      zod: 4.5.4
 
   word-wrap@1.2.5: {}
 

--- a/src/core/bridge-mesh.ts
+++ b/src/core/bridge-mesh.ts
@@ -4,7 +4,7 @@
  * peerId is deviceIdToHex(identity.deviceId), not identity.fingerprint -- WireMeshTransport's own session bookkeeping is keyed by device-id, so MeshStore's own notion of "this peer's id" has to be the same value for the two to correlate. Every existing agent id changes the first time a bridge starts through this factory: there is no migration path, since the value is a hash of genuinely different bytes (device-id is SHA-256(raw public key); fingerprint is SHA-256(certificate DER)) -- a hard cutover, already established as correct when identity.ts first grew deviceId, not relitigated here.
  */
 
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import { MeshStore } from "./mesh-store.js";
 import { CommsTool } from "./tool.js";
 import { WireMeshTransport } from "./wire-mesh-transport.js";

--- a/src/core/handshake.ts
+++ b/src/core/handshake.ts
@@ -15,7 +15,7 @@ import {
 import {
   negotiate,
   type NegotiationResult,
-} from "@exadev/wire-mesh-core/domain/handshake";
+} from "wire-mesh-core/domain/handshake";
 
 /** agent-comms' own wire-format version. 1 = the current format (entity revision fields, deliveryQueues). */
 export const MESH_PROTOCOL_VERSION = 1;

--- a/src/core/wire-mesh-identity.ts
+++ b/src/core/wire-mesh-identity.ts
@@ -3,8 +3,8 @@
  */
 
 import { webcrypto } from "node:crypto";
-import { createNodeIdentity } from "@exadev/wire-mesh-core/adapters/node-identity";
-import type { IdentityPort } from "@exadev/wire-mesh-core/ports/identity";
+import { createNodeIdentity } from "wire-mesh-core/adapters/node-identity";
+import type { IdentityPort } from "wire-mesh-core/ports/identity";
 import type { PeerIdentity } from "./identity.js";
 import { rawPublicKeyFromPrivateKey } from "./identity.js";
 

--- a/src/core/wire-mesh-transport.ts
+++ b/src/core/wire-mesh-transport.ts
@@ -1,5 +1,5 @@
 /**
- * WireMeshTransport — MeshTransport implemented over @exadev/wire-mesh-core, carrying the existing MeshMessage union as an opaque payload rather than inventing new wire semantics. This is the P2 substrate swap's own deliverable: MeshStore, CommsTool, and every existing agent/room/message behaviour above the transport are completely unaffected -- only how bytes move between peers changes.
+ * WireMeshTransport — MeshTransport implemented over wire-mesh-core, carrying the existing MeshMessage union as an opaque payload rather than inventing new wire semantics. This is the P2 substrate swap's own deliverable: MeshStore, CommsTool, and every existing agent/room/message behaviour above the transport are completely unaffected -- only how bytes move between peers changes.
  *
  * Every agent-comms MeshMessage rides as a single namespaced manage-command verb (FRAME_VERB) under one flat scope (FRAME_SCOPE); the message itself is carried opaquely in the command's own params.message field. This needs no spec/CDDL change: manage-command-params is already an open `{* tstr => any}` socket for exactly this purpose.
  *
@@ -8,22 +8,22 @@
  * connect_request's accept/reject flow maps onto sendManageRequest's own request/response round trip directly, rather than a separate pair of connect_accepted/connect_rejected messages: manage-request-frame already tolerates arbitrary latency between a request and its response, so "waiting for a human to approve" is simply a manage-response that hasn't been sent yet, not a protocol gap needing its own mechanism. connect_request therefore holds its own IncomingManageRequest open (rather than responding immediately) until acceptConnection/rejectConnection is actually called.
  */
 
-import { createTlsTransport } from "@exadev/wire-mesh-core/adapters/tls-transport";
+import { createTlsTransport } from "wire-mesh-core/adapters/tls-transport";
 import {
   acceptMeshSession,
   type AcceptedMeshSession,
   type IncomingManageRequest,
-} from "@exadev/wire-mesh-core/domain/mesh-session";
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+} from "wire-mesh-core/domain/mesh-session";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import type {
   CapabilityScope,
   ManageCommand,
-} from "@exadev/wire-mesh-core/generated/protocol";
+} from "wire-mesh-core/generated/protocol";
 import type {
   Connection,
   Listener,
   Transport,
-} from "@exadev/wire-mesh-core/ports/transport";
+} from "wire-mesh-core/ports/transport";
 import { isMeshMessage } from "./wire-protocol.js";
 import type { MeshMessage, PeerInfo } from "./wire-protocol.js";
 import type {

--- a/src/test/approval.integration.test.ts
+++ b/src/test/approval.integration.test.ts
@@ -9,8 +9,8 @@
 import * as net from "node:net";
 import * as assert from "node:assert/strict";
 import { test, describe } from "node:test";
-import { createTlsTransport } from "@exadev/wire-mesh-core/adapters/tls-transport";
-import { acceptMeshSession } from "@exadev/wire-mesh-core/domain/mesh-session";
+import { createTlsTransport } from "wire-mesh-core/adapters/tls-transport";
+import { acceptMeshSession } from "wire-mesh-core/domain/mesh-session";
 import { MeshStore } from "../core/mesh-store.js";
 import { CommsTool } from "../core/tool.js";
 import { buildAction } from "../core/bridge.js";

--- a/src/test/become-coordinator-actual-port.integration.test.ts
+++ b/src/test/become-coordinator-actual-port.integration.test.ts
@@ -5,8 +5,8 @@
  */
 
 import * as assert from "node:assert/strict";
-import { createTlsTransport } from "@exadev/wire-mesh-core/adapters/tls-transport";
-import { acceptMeshSession } from "@exadev/wire-mesh-core/domain/mesh-session";
+import { createTlsTransport } from "wire-mesh-core/adapters/tls-transport";
+import { acceptMeshSession } from "wire-mesh-core/domain/mesh-session";
 import { WireMeshTransport, DOMAIN } from "../core/wire-mesh-transport.js";
 import { generateIdentity } from "../core/identity.js";
 import { toIdentityPort } from "../core/wire-mesh-identity.js";

--- a/src/test/bridge-mesh.test.ts
+++ b/src/test/bridge-mesh.test.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import { createBridgeMesh } from "../core/bridge-mesh.js";
 import {
   loadOrCreateIdentity,

--- a/src/test/broadcast-window.integration.test.ts
+++ b/src/test/broadcast-window.integration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import * as assert from "node:assert/strict";
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import { MeshStore } from "../core/mesh-store.js";
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
 import { generateIdentity } from "../core/identity.js";

--- a/src/test/downtime-replay.integration.test.ts
+++ b/src/test/downtime-replay.integration.test.ts
@@ -8,7 +8,7 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import { MeshStore } from "../core/mesh-store.js";
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
 import { generateIdentity } from "../core/identity.js";

--- a/src/test/identity-restart.integration.test.ts
+++ b/src/test/identity-restart.integration.test.ts
@@ -8,7 +8,7 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import { MeshStore } from "../core/mesh-store.js";
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
 import { generateIdentity } from "../core/identity.js";

--- a/src/test/listener-policy.integration.test.ts
+++ b/src/test/listener-policy.integration.test.ts
@@ -7,8 +7,8 @@
  */
 
 import * as net from "node:net";
-import { createTlsTransport } from "@exadev/wire-mesh-core/adapters/tls-transport";
-import { acceptMeshSession } from "@exadev/wire-mesh-core/domain/mesh-session";
+import { createTlsTransport } from "wire-mesh-core/adapters/tls-transport";
+import { acceptMeshSession } from "wire-mesh-core/domain/mesh-session";
 import { MeshStore } from "../core/mesh-store.js";
 import { CommsTool } from "../core/tool.js";
 import { buildAction } from "../core/bridge.js";

--- a/src/test/mesh-smoke.runner.ts
+++ b/src/test/mesh-smoke.runner.ts
@@ -111,7 +111,7 @@ function buildScript(name: string, actions: string): string {
     `const { CommsTool } = require("./dist/core/tool.js");`,
     `const { WireMeshTransport } = require("./dist/core/wire-mesh-transport.js");`,
     `const { generateIdentity } = require("./dist/core/identity.js");`,
-    `const { deviceIdToHex } = require("@exadev/wire-mesh-core/domain/device-id");`,
+    `const { deviceIdToHex } = require("wire-mesh-core/domain/device-id");`,
     `function log(msg) { process.stdout.write(JSON.stringify(msg) + "\\n"); }`,
     `(async () => {`,
     `  const store = new MeshStore(${String(SMOKE_PORT)});`,

--- a/src/test/test-transport.ts
+++ b/src/test/test-transport.ts
@@ -2,7 +2,7 @@
 
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
 import { generateIdentity } from "../core/identity.js";
-import { deviceIdToHex } from "@exadev/wire-mesh-core/domain/device-id";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import type { MeshStore } from "../core/mesh-store.js";
 
 export function wireTestTransport(store: MeshStore): void {


### PR DESCRIPTION
wire-mesh's core package used to be committed as a git-subdirectory dependency (github:ExaDev/wire-mesh#path:ts/packages/core) because its build output had to be committed for a git install to have anything to load with no build step available. That's now been replaced with real npm publishing on the wire-mesh side (wire-mesh-core, unscoped -- renamed from @exadev/wire-mesh-core to match its npm trusted-publisher configuration), and dist/ was purged from wire-mesh's own git history entirely, which broke the old git-dependency reference outright.

This depends on the real published wire-mesh-core@1.0.1 instead, matching every other npm dependency in this project. Verified: build, lint, the full test suite (85 tests), and the multi-process smoke test (real subprocesses forming a real mesh) all pass unchanged against the real package.