### PR TITLE
feat(core): add the six-obligation room-token verification helper (part of P3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "cbor2": "2.3.0",
     "preact": "10.29.7",
     "typebox": "1.3.6",
-    "wire-mesh-core": "1.0.1",
+    "wire-mesh-core": "1.0.2",
     "ws": "8.21.1",
     "zod": "4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 1.3.6
         version: 1.3.6
       wire-mesh-core:
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.0.2
+        version: 1.0.2
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -3235,8 +3235,8 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  wire-mesh-core@1.0.1:
-    resolution: {integrity: sha512-dYA5O6j3/+uv9zta8tXrqZq0o0+JEb1gMIzELPjHJmqQtG33a7QeE2aszsYgHbpieOX6FU8INryU8gej6g2ZyA==}
+  wire-mesh-core@1.0.2:
+    resolution: {integrity: sha512-MV+odiI9DQXsGWJ9FiOs8hbZxseLEua2JfosRlPdPIByOMcM8/PYkgtbPt8hyPuYyYl21QHTQVputzGkyL69Zw==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -6780,7 +6780,7 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  wire-mesh-core@1.0.1:
+  wire-mesh-core@1.0.2:
     dependencies:
       cbor2: 2.3.0
       cddl.js: 1.0.1

--- a/src/core/room-token-verification.ts
+++ b/src/core/room-token-verification.ts
@@ -1,0 +1,72 @@
+/**
+ * core/room's six verifier obligations (spec/room.cddl), layered on top of verifyCapabilityToken (obligations 2, 4, and 5 -- bearer match, ordinary token-claims checks, and delegations-remaining narrowing -- already live there). This module adds the two obligations specific to room-shaped scopes: the chain must terminate at the correct root for the path's own shape (1), and the token's own scope must actually name the room the request claims to act on (3). Obligation 6 (refuse an unrecognised content-type/kind) is a message-handling concern, not a token-verification one, and belongs to the room verb router instead.
+ */
+
+import {
+  verifyCapabilityToken,
+  type TokenVerdictReason,
+  type VerifyCapabilityTokenOptions,
+} from "wire-mesh-core/domain/tokens";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
+import type {
+  CapabilityToken,
+  DeviceId,
+  TokenClaims,
+} from "wire-mesh-core/generated/protocol";
+import { parseRoomPath } from "./room-path.js";
+
+export type RoomTokenVerdictReason =
+  | TokenVerdictReason
+  | "wrong_scope_kind"
+  | "wrong_scope_path"
+  | "wrong_chain_root";
+
+export type RoomTokenVerdict =
+  | { ok: true; claims: TokenClaims }
+  | { ok: false; reason: RoomTokenVerdictReason };
+
+export interface VerifyRoomTokenOptions extends Omit<
+  VerifyCapabilityTokenOptions,
+  "expectedBearer"
+> {
+  /** The peer identity actually authenticated on the arriving connection (obligation 2) -- never a relay-asserted or gossip-derived value. Mandatory here: every room verb requires a bearer, unlike verifyCapabilityToken's own optional field for callers presenting a token to authorise themselves rather than a specific counterparty. */
+  expectedBearer: DeviceId;
+  /** The room path this request claims to act on (obligation 3) -- must equal the token's own scope.path, and its own shape determines the chain root obligation 1 requires. */
+  roomPath: string;
+}
+
+/**
+ * Verifies a `room:member` capability token against all six of core/room's verifier obligations. Delegates obligations 2/4/5 to verifyCapabilityToken directly; adds obligation 3 (scope.kind/scope.path must match the room being acted on) and obligation 1 (the chain's root must be the room's own owner for a named room, or the verifying identity itself for a DM -- never either named participant directly, since a DM token minted by anyone other than the verifier would let a sender self-issue authority to message a stranger unsolicited).
+ */
+export async function verifyRoomToken(
+  token: CapabilityToken,
+  options: VerifyRoomTokenOptions,
+): Promise<RoomTokenVerdict> {
+  const verdict = await verifyCapabilityToken(token, {
+    identity: options.identity,
+    clock: options.clock,
+    revocation: options.revocation,
+    expectedBearer: options.expectedBearer,
+  });
+  if (!verdict.ok) {
+    return verdict;
+  }
+
+  if (verdict.claims.scope.kind !== "room") {
+    return { ok: false, reason: "wrong_scope_kind" };
+  }
+  if (verdict.claims.scope.path !== options.roomPath) {
+    return { ok: false, reason: "wrong_scope_path" };
+  }
+
+  const parsed = parseRoomPath(options.roomPath);
+  const expectedRootHex =
+    parsed.kind === "owner-named"
+      ? parsed.owner
+      : deviceIdToHex(options.identity.deviceId);
+  if (deviceIdToHex(verdict.rootIssuer) !== expectedRootHex) {
+    return { ok: false, reason: "wrong_chain_root" };
+  }
+
+  return { ok: true, claims: verdict.claims };
+}

--- a/src/test/room-token-verification.test.ts
+++ b/src/test/room-token-verification.test.ts
@@ -1,0 +1,284 @@
+import { webcrypto } from "node:crypto";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createNodeIdentity } from "wire-mesh-core/adapters/node-identity";
+import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
+import {
+  mintCapabilityToken,
+  mintRevocationEntry,
+} from "wire-mesh-core/domain/tokens";
+import { createRevocationView } from "wire-mesh-core/domain/revocation-view";
+import type { IdentityPort } from "wire-mesh-core/ports/identity";
+import type { Clock } from "wire-mesh-core/ports/clock";
+import type { CapabilityToken } from "wire-mesh-core/generated/protocol";
+import { ownerNamedRoomPath, dmRoomPath } from "../core/room-path.js";
+import { verifyRoomToken } from "../core/room-token-verification.js";
+
+const ES256 = -7;
+const HOUR_MS = 3_600_000;
+
+function buf(bytes: Uint8Array | ArrayLike<number>): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(bytes);
+}
+
+async function generateEs256Identity(): Promise<IdentityPort> {
+  const keyPair = await webcrypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  );
+  const publicKeyBytes = new Uint8Array(
+    await webcrypto.subtle.exportKey("raw", keyPair.publicKey),
+  );
+  return createNodeIdentity(keyPair.privateKey, publicKeyBytes, ES256);
+}
+
+function fixedClock(atMs: number): Clock {
+  return { now: () => atMs };
+}
+
+let issuedTokenIds = 0;
+function nextTokenId(): Uint8Array<ArrayBuffer> {
+  issuedTokenIds += 1;
+  return buf([issuedTokenIds]);
+}
+
+const NOW_MS = 1_893_456_000_000;
+const EXPIRES_MS = NOW_MS + HOUR_MS;
+
+async function mintRoomMemberToken(
+  issuer: IdentityPort,
+  bearer: IdentityPort,
+  roomPath: string,
+  tokenId: Uint8Array<ArrayBuffer> = nextTokenId(),
+): Promise<CapabilityToken> {
+  const verdict = await mintCapabilityToken({
+    identity: issuer,
+    clock: fixedClock(NOW_MS),
+    tokenId,
+    bearer: bearer.deviceId,
+    capability: "room:member",
+    scope: { kind: "room", path: roomPath },
+    expires: EXPIRES_MS,
+    delegationsRemaining: 0,
+  });
+  if (!verdict.ok) throw new Error(`mint failed: ${verdict.reason}`);
+  return verdict.token;
+}
+
+describe("verifyRoomToken", () => {
+  it("accepts a token rooted at the named room's own owner", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    const token = await mintRoomMemberToken(owner, member, roomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: member.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, true);
+  });
+
+  it("refuses a token rooted at the wrong device for a named room", async () => {
+    const owner = await generateEs256Identity();
+    const impostor = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    // Minted by the impostor, not the room's actual owner -- rootIssuer will be the impostor's own device-id, not the path's owner.
+    const token = await mintRoomMemberToken(impostor, member, roomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: member.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "wrong_chain_root");
+  });
+
+  it("accepts a DM token rooted at the verifying identity itself", async () => {
+    const me = await generateEs256Identity();
+    const them = await generateEs256Identity();
+    const roomPath = dmRoomPath(
+      deviceIdToHex(me.deviceId),
+      deviceIdToHex(them.deviceId),
+    );
+    // I (the verifier) issue the token that lets `them` send to me.
+    const token = await mintRoomMemberToken(me, them, roomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: me,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: them.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, true);
+  });
+
+  it("refuses a DM token rooted at neither participant nor the verifier", async () => {
+    const me = await generateEs256Identity();
+    const them = await generateEs256Identity();
+    const stranger = await generateEs256Identity();
+    const roomPath = dmRoomPath(
+      deviceIdToHex(me.deviceId),
+      deviceIdToHex(them.deviceId),
+    );
+    // A stranger self-issues a token for this DM path -- must never verify, since the DM path's only acceptable root is the verifier itself.
+    const token = await mintRoomMemberToken(stranger, them, roomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: me,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: them.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "wrong_chain_root");
+  });
+
+  it("refuses a token scoped to a different room path", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const actualRoomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    const otherRoomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "other-room",
+    );
+    const token = await mintRoomMemberToken(owner, member, actualRoomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: member.deviceId,
+      roomPath: otherRoomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "wrong_scope_path");
+  });
+
+  it("refuses a token scoped to a non-room capability", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    const verdict1 = await mintCapabilityToken({
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      tokenId: nextTokenId(),
+      bearer: member.deviceId,
+      capability: "exec:pty",
+      scope: { kind: "folder" },
+      expires: EXPIRES_MS,
+    });
+    if (!verdict1.ok) throw new Error(`mint failed: ${verdict1.reason}`);
+
+    const verdict = await verifyRoomToken(verdict1.token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: member.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "wrong_scope_kind");
+  });
+
+  it("refuses a token bearing a different device than the authenticated connection", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const impostor = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    const token = await mintRoomMemberToken(owner, member, roomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: impostor.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "bearer_mismatch");
+  });
+
+  it("refuses an expired token", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    const token = await mintRoomMemberToken(owner, member, roomPath);
+
+    const verdict = await verifyRoomToken(token, {
+      identity: owner,
+      clock: fixedClock(EXPIRES_MS + HOUR_MS),
+      revocation: createRevocationView(),
+      expectedBearer: member.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "expired");
+  });
+
+  it("refuses a revoked token", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    const tokenId = nextTokenId();
+    const token = await mintRoomMemberToken(owner, member, roomPath, tokenId);
+
+    const revocation = createRevocationView();
+    const entry = await mintRevocationEntry({
+      identity: owner,
+      tokenId,
+      revokedAt: NOW_MS,
+    });
+    await revocation.record(entry, { identity: owner });
+
+    const verdict = await verifyRoomToken(token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation,
+      expectedBearer: member.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "revoked");
+  });
+});


### PR DESCRIPTION
Part of #48 (P3: real core/room semantics), the verification-helper piece of P3.2. Persisting a per-room token set and plumbing Connection.peerDeviceId through WireMeshTransport are tracked separately, since they don't depend on this helper existing first.

verifyRoomToken layers core/room's two scope-specific verifier obligations on top of verifyCapabilityToken, which already covers the other four (bearer match, signature/expiry/revocation, and delegations-remaining narrowing): the token's scope must actually name the room the request claims to act on, and the delegation chain must terminate at the correct root for that path's own shape -- the room's owner for a named room, or the verifying identity itself for a DM, never either named participant directly (a DM token minted by anyone else would let a sender self-issue authority to message a stranger unsolicited).

Obligation 6 (refuse an unrecognised content-type/kind) is deliberately left to the room verb router (P3.3) instead, since it's a message-handling concern rather than a token-verification one.

No verb handling wired up yet -- exercised directly by 9 unit tests covering each obligation as its own negative case. Found and fixed a real gap in wire-mesh along the way: createRevocationView (added in wire-mesh#66) had never been added to the package's build entry list or exports map, so it was completely unreachable from this package despite being fully built and tested inside wire-mesh's own repo (wire-mesh#76, merged, wire-mesh-core@1.0.2).