### PR TITLE
feat(core): persist a per-room capability token set in the identity slot (part of P3.2)

### DIFF
--- a/src/core/identity-store.ts
+++ b/src/core/identity-store.ts
@@ -1,14 +1,15 @@
 /**
- * Persistent bridge identity: load-or-create the TLS key material for a (harness, cwd) slot so the certificate fingerprint — and therefore the peer and agent ID — survives restarts.
+ * Persistent bridge identity: load-or-create the TLS key material for a (harness, cwd) slot so the device-id -- and therefore the peer and agent ID -- survives restarts. Also persists a per-room capability token set in the same slot, so a room membership grant survives a restart the same way the identity it was minted against does.
  *
- * Mesh state stays in memory and on the wire; the only thing on disk is this local credential, the same trust model as an SSH key. A lock file holding a PID keeps two live bridges in one slot from sharing an identity, which would put duplicate peer IDs on the mesh; the second bridge runs with an ephemeral identity (the behaviour before persistence) instead. Bridges without a graceful shutdown hook can skip releasing the lock: a stale lock is detected by probing the recorded PID, the same way the coordinator probes for stale agents.
+ * Mesh state stays in memory and on the wire; the only thing on disk is this local credential (plus, now, the tokens minted against it), the same trust model as an SSH key. A lock file holding a PID keeps two live bridges in one slot from sharing an identity, which would put duplicate peer IDs on the mesh; the second bridge runs with an ephemeral identity (the behaviour before persistence) instead. Bridges without a graceful shutdown hook can skip releasing the lock: a stale lock is detected by probing the recorded PID, the same way the coordinator probes for stale agents.
  *
- * Persisting the key material rather than a bare agent ID is what makes restarts work: delivery routing fires when agentId === peerId, and peerId is the live certificate fingerprint, so an ID without its key can never match the running peer.
+ * Persisting the key material rather than a bare agent ID is what makes restarts work: delivery routing fires when agentId === peerId, and peerId is deviceIdToHex(identity.deviceId), so an ID without its key can never match the running peer. Renewal near certificate expiry currently generates an entirely fresh key pair rather than re-certifying the existing one, which silently rotates the device-id (and so invalidates any persisted room tokens bound to it) -- a real, separately tracked gap (#68), not addressed here.
  */
 
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { CapabilityToken } from "wire-mesh-core/generated/protocol";
 import {
   generateIdentity,
   getCertificateFingerprint,
@@ -28,10 +29,34 @@ export interface IdentitySlot {
 /** Renew during the final twelfth of the certificate's validity. */
 const RENEWAL_MARGIN_MS = CERTIFICATE_VALIDITY_MS / 12;
 
+/** A CapabilityToken (COSE_Sign1: [protected header bytes, unprotected header map, payload bytes or null, signature bytes]) with every byte-string field base64-encoded for JSON storage. Only the two named unprotected-header fields (alg, kid) are round-tripped -- every token minted by wire-mesh-core today leaves the unprotected header empty (alg/kid live in the protected header instead), so the schema's own open catchall for arbitrary extra keys is left unhandled until a real caller actually needs one preserved. */
+type SerializedCapabilityToken = [
+  string,
+  { "1"?: number; "4"?: string; [key: string]: unknown },
+  string | null,
+  string,
+];
+
 interface StoredIdentity {
   privateKey: string;
   certificate: string;
   expiresAt: string;
+  roomTokens?: Record<string, SerializedCapabilityToken>;
+}
+
+function isSerializedCapabilityToken(
+  value: unknown,
+): value is SerializedCapabilityToken {
+  if (!Array.isArray(value) || value.length !== 4) return false;
+  const protectedHeader: unknown = value[0];
+  const unprotectedHeader: unknown = value[1];
+  const payload: unknown = value[2];
+  const signature: unknown = value[3];
+  if (typeof protectedHeader !== "string") return false;
+  if (typeof unprotectedHeader !== "object" || unprotectedHeader === null)
+    return false;
+  if (payload !== null && typeof payload !== "string") return false;
+  return typeof signature === "string";
 }
 
 function isStoredIdentity(value: unknown): value is StoredIdentity {
@@ -42,11 +67,56 @@ function isStoredIdentity(value: unknown): value is StoredIdentity {
     !("expiresAt" in value)
   )
     return false;
-  return (
-    typeof value.privateKey === "string" &&
-    typeof value.certificate === "string" &&
-    typeof value.expiresAt === "string"
-  );
+  if (
+    typeof value.privateKey !== "string" ||
+    typeof value.certificate !== "string" ||
+    typeof value.expiresAt !== "string"
+  )
+    return false;
+  if (!("roomTokens" in value)) return true;
+  const { roomTokens } = value;
+  if (typeof roomTokens !== "object" || roomTokens === null) return false;
+  return Object.values(roomTokens).every(isSerializedCapabilityToken);
+}
+
+function serializeToken(token: CapabilityToken): SerializedCapabilityToken {
+  const [protectedHeader, unprotectedHeader, payload, signature] = token;
+  const serializedUnprotected: SerializedCapabilityToken[1] = {
+    ...(unprotectedHeader["1"] !== undefined
+      ? { "1": unprotectedHeader["1"] }
+      : {}),
+    ...(unprotectedHeader["4"] !== undefined
+      ? { "4": Buffer.from(unprotectedHeader["4"]).toString("base64") }
+      : {}),
+  };
+  return [
+    Buffer.from(protectedHeader).toString("base64"),
+    serializedUnprotected,
+    payload === null ? null : Buffer.from(payload).toString("base64"),
+    Buffer.from(signature).toString("base64"),
+  ];
+}
+
+function deserializeToken(
+  serialized: SerializedCapabilityToken,
+): CapabilityToken {
+  const [protectedHeader, unprotectedHeader, payload, signature] = serialized;
+  const deserializedUnprotected: CapabilityToken[1] = {
+    ...(unprotectedHeader["1"] !== undefined
+      ? { "1": unprotectedHeader["1"] }
+      : {}),
+    ...(unprotectedHeader["4"] !== undefined
+      ? {
+          "4": Uint8Array.from(Buffer.from(unprotectedHeader["4"], "base64")),
+        }
+      : {}),
+  };
+  return [
+    Uint8Array.from(Buffer.from(protectedHeader, "base64")),
+    deserializedUnprotected,
+    payload === null ? null : Uint8Array.from(Buffer.from(payload, "base64")),
+    Uint8Array.from(Buffer.from(signature, "base64")),
+  ];
 }
 
 /** Replace path separators and other filesystem-hostile characters. */
@@ -170,4 +240,74 @@ export function releaseIdentityLock(slot: IdentitySlot): void {
   if (readLockPid(lockFile) === process.pid) {
     fs.rmSync(lockFile, { force: true });
   }
+}
+
+/** Reads the slot's raw stored identity record, or undefined if the file is missing or unparseable. Used by the room-token functions below to read-modify-write only the roomTokens field, leaving the persisted key material exactly as it is. */
+function readStoredIdentity(identityFile: string): StoredIdentity | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(identityFile, "utf-8"));
+  } catch {
+    return undefined;
+  }
+  return isStoredIdentity(parsed) ? parsed : undefined;
+}
+
+function writeStoredIdentity(
+  identityFile: string,
+  stored: StoredIdentity,
+): void {
+  fs.writeFileSync(identityFile, `${JSON.stringify(stored, null, 2)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+}
+
+/**
+ * Every room-membership capability token persisted for this slot, keyed by room path. Empty if the slot has never had one saved (or the identity file doesn't exist yet -- call loadOrCreateIdentity first).
+ */
+export function loadRoomTokens(
+  slot: IdentitySlot,
+): Record<string, CapabilityToken> {
+  const { identityFile } = slotPaths(slot);
+  const stored = readStoredIdentity(identityFile);
+  const serialized = stored?.roomTokens ?? {};
+  const tokens: Record<string, CapabilityToken> = {};
+  for (const [roomPath, token] of Object.entries(serialized)) {
+    tokens[roomPath] = deserializeToken(token);
+  }
+  return tokens;
+}
+
+/**
+ * Persists a capability token for the given room path, surviving a restart the same way the identity it was minted against does. Overwrites any token already saved for that room; leaves every other room's token and the identity's own key material untouched.
+ */
+export function saveRoomToken(
+  slot: IdentitySlot,
+  roomPath: string,
+  token: CapabilityToken,
+): void {
+  const { identityFile } = slotPaths(slot);
+  const stored = readStoredIdentity(identityFile);
+  if (stored === undefined) {
+    throw new Error(
+      `no identity persisted for this slot yet -- call loadOrCreateIdentity first (${identityFile})`,
+    );
+  }
+  const roomTokens = {
+    ...stored.roomTokens,
+    [roomPath]: serializeToken(token),
+  };
+  writeStoredIdentity(identityFile, { ...stored, roomTokens });
+}
+
+/** Removes the persisted token for one room path, if any. A no-op if none was saved for that path. */
+export function deleteRoomToken(slot: IdentitySlot, roomPath: string): void {
+  const { identityFile } = slotPaths(slot);
+  const stored = readStoredIdentity(identityFile);
+  if (stored?.roomTokens === undefined) return;
+  const roomTokens = Object.fromEntries(
+    Object.entries(stored.roomTokens).filter(([path]) => path !== roomPath),
+  );
+  writeStoredIdentity(identityFile, { ...stored, roomTokens });
 }

--- a/src/test/room-token-store.test.ts
+++ b/src/test/room-token-store.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for per-room capability token persistence (core/identity-store).
+ */
+
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import type { CapabilityToken } from "wire-mesh-core/generated/protocol";
+import {
+  loadOrCreateIdentity,
+  loadRoomTokens,
+  saveRoomToken,
+  deleteRoomToken,
+  releaseIdentityLock,
+  type IdentitySlot,
+} from "../core/identity-store.js";
+
+function tempSlot(harness: string): { slot: IdentitySlot; dir: string } {
+  const dir = fs.mkdtempSync(
+    path.join(tmpdir(), "agent-comms-room-token-test-"),
+  );
+  return { slot: { harness, cwd: "/tmp/project", dir }, dir };
+}
+
+function buf(bytes: number[]): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(bytes);
+}
+
+const TOKEN_A: CapabilityToken = [
+  buf([1, 2, 3]),
+  {},
+  buf([4, 5, 6]),
+  buf([7, 8, 9]),
+];
+const TOKEN_B: CapabilityToken = [
+  buf([10, 11]),
+  { 1: -7 },
+  null,
+  buf([12, 13, 14]),
+];
+const ROOM_A = "aa".repeat(32) + "/general";
+const ROOM_B = "bb".repeat(32) + "/other-room";
+
+void test("loadRoomTokens returns an empty map before anything is saved", () => {
+  const { slot } = tempSlot("pi");
+  loadOrCreateIdentity(slot);
+  assert.deepEqual(loadRoomTokens(slot), {});
+  releaseIdentityLock(slot);
+});
+
+void test("saveRoomToken persists a token retrievable by loadRoomTokens", () => {
+  const { slot } = tempSlot("claude-code");
+  loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_A, TOKEN_A);
+
+  const tokens = loadRoomTokens(slot);
+  assert.deepEqual(tokens[ROOM_A], TOKEN_A);
+  releaseIdentityLock(slot);
+});
+
+void test("saveRoomToken round-trips a token whose payload is null", () => {
+  const { slot } = tempSlot("codex");
+  loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_B, TOKEN_B);
+
+  const tokens = loadRoomTokens(slot);
+  assert.deepEqual(tokens[ROOM_B], TOKEN_B);
+  releaseIdentityLock(slot);
+});
+
+void test("saveRoomToken for a second room does not disturb the first", () => {
+  const { slot } = tempSlot("mcp");
+  loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_A, TOKEN_A);
+  saveRoomToken(slot, ROOM_B, TOKEN_B);
+
+  const tokens = loadRoomTokens(slot);
+  assert.deepEqual(tokens[ROOM_A], TOKEN_A);
+  assert.deepEqual(tokens[ROOM_B], TOKEN_B);
+  releaseIdentityLock(slot);
+});
+
+void test("saveRoomToken overwrites an existing token for the same room", () => {
+  const { slot } = tempSlot("opencode");
+  loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_A, TOKEN_A);
+  saveRoomToken(slot, ROOM_A, TOKEN_B);
+
+  const tokens = loadRoomTokens(slot);
+  assert.deepEqual(tokens[ROOM_A], TOKEN_B);
+  assert.equal(Object.keys(tokens).length, 1);
+  releaseIdentityLock(slot);
+});
+
+void test("deleteRoomToken removes only the named room's token", () => {
+  const { slot } = tempSlot("user");
+  loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_A, TOKEN_A);
+  saveRoomToken(slot, ROOM_B, TOKEN_B);
+
+  deleteRoomToken(slot, ROOM_A);
+
+  const tokens = loadRoomTokens(slot);
+  assert.equal(ROOM_A in tokens, false);
+  assert.deepEqual(tokens[ROOM_B], TOKEN_B);
+  releaseIdentityLock(slot);
+});
+
+void test("room tokens survive reloading the identity file across a fresh load", () => {
+  const { slot } = tempSlot("pi");
+  loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_A, TOKEN_A);
+  releaseIdentityLock(slot);
+
+  // A fresh process re-loading the same slot.
+  loadOrCreateIdentity(slot);
+  const tokens = loadRoomTokens(slot);
+  assert.deepEqual(tokens[ROOM_A], TOKEN_A);
+  releaseIdentityLock(slot);
+});
+
+void test("saving a room token does not disturb the persisted key material", () => {
+  const { slot } = tempSlot("claude-code");
+  const identity = loadOrCreateIdentity(slot);
+  saveRoomToken(slot, ROOM_A, TOKEN_A);
+
+  const reloaded = loadOrCreateIdentity(slot);
+  assert.equal(reloaded.privateKey, identity.privateKey);
+  assert.equal(reloaded.certificate, identity.certificate);
+  releaseIdentityLock(slot);
+});


### PR DESCRIPTION
Part of #48 (P3: real core/room semantics), the remaining piece of P3.2 (the verification helper itself merged in #67). Connection.peerDeviceId plumbing turned out to need no code change: every ConnectionHandle.id in WireMeshTransport is already the lossless hex encoding of the TLS-authenticated device-id, and deviceIdFromHex (already exported from wire-mesh-core) is a trivial, correct inverse -- passing it into whatever the P3.3 router introduces is that phase's own natural concern, not a separable P3.2 deliverable.

loadRoomTokens/saveRoomToken/deleteRoomToken read-modify-write only the new roomTokens field of the slot's existing identity file, leaving the persisted key material untouched. A CapabilityToken is a COSE_Sign1 4-tuple with three byte-string fields, none of them JSON-safe as-is, so each is base64-encoded for storage and decoded back on load.

A room membership grant needs this the same way the identity it was minted against does: without it, every restart would mean re-approving every room membership from scratch, since the token itself never survived to prove it had already happened.

Filed #68 while working on this: renewal near certificate expiry generates an entirely fresh key pair rather than re-certifying the existing one, silently rotating the device-id a persisted room token is bound to. Real, but a separate concern from persisting the token set itself -- not fixed here.