### PR TITLE
fix(core): reject a room token whose own capability isn't room:member

### DIFF
--- a/src/core/room-token-verification.ts
+++ b/src/core/room-token-verification.ts
@@ -1,5 +1,5 @@
 /**
- * core/room's six verifier obligations (spec/room.cddl), layered on top of verifyCapabilityToken (obligations 2, 4, and 5 -- bearer match, ordinary token-claims checks, and delegations-remaining narrowing -- already live there). This module adds the two obligations specific to room-shaped scopes: the chain must terminate at the correct root for the path's own shape (1), and the token's own scope must actually name the room the request claims to act on (3). Obligation 6 (refuse an unrecognised content-type/kind) is a message-handling concern, not a token-verification one, and belongs to the room verb router instead.
+ * core/room's six verifier obligations (spec/room.cddl), layered on top of verifyCapabilityToken (obligations 2, 4, and 5 -- bearer match, ordinary token-claims checks, and delegations-remaining narrowing -- already live there). This module adds the checks specific to room-shaped scopes: the token must actually carry the room:member capability the six obligations presuppose (room.cddl's own obligation 1 opens with "a room:member token's delegation chain..." -- a token minted for some other capability that happens to be scoped to a room path must not pass just because scope.kind/path line up), the chain must terminate at the correct root for the path's own shape (1), and the token's own scope must actually name the room the request claims to act on (3). Obligation 6 (refuse an unrecognised content-type/kind) is a message-handling concern, not a token-verification one, and belongs to the room verb router instead.
  */
 
 import {
@@ -15,8 +15,12 @@ import type {
 } from "wire-mesh-core/generated/protocol";
 import { parseRoomPath } from "./room-path.js";
 
+/** The one capability that authorises every ordinary room-membership verb (room.send/read/leave/members) -- "one resource, not several", the same pattern exec:pty already uses for its own four inner verbs. room.join/room.invite are deliberately ungated and never reach this check at all. */
+const ROOM_MEMBER_CAPABILITY = "room:member";
+
 export type RoomTokenVerdictReason =
   | TokenVerdictReason
+  | "wrong_capability"
   | "wrong_scope_kind"
   | "wrong_scope_path"
   | "wrong_chain_root";
@@ -52,6 +56,9 @@ export async function verifyRoomToken(
     return verdict;
   }
 
+  if (verdict.claims.capability !== ROOM_MEMBER_CAPABILITY) {
+    return { ok: false, reason: "wrong_capability" };
+  }
   if (verdict.claims.scope.kind !== "room") {
     return { ok: false, reason: "wrong_scope_kind" };
   }

--- a/src/test/room-token-verification.test.ts
+++ b/src/test/room-token-verification.test.ts
@@ -179,7 +179,7 @@ describe("verifyRoomToken", () => {
     if (!verdict.ok) assert.equal(verdict.reason, "wrong_scope_path");
   });
 
-  it("refuses a token scoped to a non-room capability", async () => {
+  it("refuses a token with an unrelated capability and an unrelated scope kind", async () => {
     const owner = await generateEs256Identity();
     const member = await generateEs256Identity();
     const roomPath = ownerNamedRoomPath(
@@ -206,7 +206,38 @@ describe("verifyRoomToken", () => {
     });
 
     assert.equal(verdict.ok, false);
-    if (!verdict.ok) assert.equal(verdict.reason, "wrong_scope_kind");
+    if (!verdict.ok) assert.equal(verdict.reason, "wrong_capability");
+  });
+
+  it("refuses a token with the wrong capability even when its scope is correctly shaped for the room", async () => {
+    const owner = await generateEs256Identity();
+    const member = await generateEs256Identity();
+    const roomPath = ownerNamedRoomPath(
+      deviceIdToHex(owner.deviceId),
+      "general",
+    );
+    // Nonsensical, but not structurally prevented at mint time: capability and scope disagree about what this token actually grants. Neither scope.kind nor scope.path alone can catch this -- only checking the capability itself can.
+    const verdict1 = await mintCapabilityToken({
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      tokenId: nextTokenId(),
+      bearer: member.deviceId,
+      capability: "exec:pty",
+      scope: { kind: "room", path: roomPath },
+      expires: EXPIRES_MS,
+    });
+    if (!verdict1.ok) throw new Error(`mint failed: ${verdict1.reason}`);
+
+    const verdict = await verifyRoomToken(verdict1.token, {
+      identity: owner,
+      clock: fixedClock(NOW_MS),
+      revocation: createRevocationView(),
+      expectedBearer: member.deviceId,
+      roomPath,
+    });
+
+    assert.equal(verdict.ok, false);
+    if (!verdict.ok) assert.equal(verdict.reason, "wrong_capability");
   });
 
   it("refuses a token bearing a different device than the authenticated connection", async () => {


### PR DESCRIPTION
Part of #48 (P3: real core/room semantics) -- a real gap found in #67's own verifyRoomToken while designing P3.3's verb router, not caught before merge.

verifyRoomToken checked scope.kind/scope.path and the chain's root, but never checked the token's own capability claim against room:member, the fixed capability room.cddl documents as authorising every ordinary room-membership verb. Nothing structurally prevents minting a token with, say, capability "exec:pty" and scope {kind: "room", path: ...} -- mintCapabilityToken has no cross-check between the two fields -- so such a token would have passed every existing check despite granting an entirely different authority.

room.cddl's own obligation 1 opens with "a room:member token's delegation chain..." -- the capability match was always a precondition the six obligations presuppose, just never turned into an explicit check until now.