### PR TITLE
feat(core): extract verb-routed dispatch into a dedicated room router

### DIFF
--- a/src/core/room-router.ts
+++ b/src/core/room-router.ts
@@ -1,0 +1,136 @@
+/**
+ * The room verb router: one drain loop per session, dispatching each incoming manage-request by verb. A legacy FRAME_VERB command (P2's opaque-payload carriage, still the only path for anything core/room doesn't yet have real semantics for) decodes and routes to the matching TransportEvents callback exactly as WireMeshTransport used to do inline; a registered room verb (room.send, room.join, ...) goes to its own handler; anything else -- an unrecognised verb, or a room verb this phase hasn't registered a handler for yet -- gets unsupported_verb rather than silence.
+ *
+ * core/room's own manage-command shape puts the specific action in params.verb (room.send, room.join, ...), not in the outer command.verb, which is instead the single room:member capability every ordinary membership verb shares (room.join/room.invite are ungated and carry no token at all, but still ride command.verb === "room:member" -- see spec/room.cddl and its own conformance vectors). Dispatch is therefore keyed on params.verb, not command.verb.
+ *
+ * Deliberately empty of real room-verb handlers in this phase (P3.3): the router itself, and the unsupported_verb fallback, are the whole deliverable here. Each later phase (P3.4 admission, P3.5 fan-out, P3.6 state-sync, P3.7 kick) registers the handlers for the verbs it implements.
+ */
+
+import type {
+  AcceptedMeshSession,
+  IncomingManageRequest,
+  ManageOutcome,
+} from "wire-mesh-core/domain/mesh-session";
+import { isMeshMessage } from "./wire-protocol.js";
+import type { MeshMessage } from "./wire-protocol.js";
+import type { ConnectionHandle, TransportEvents } from "./transport.js";
+import { FRAME_VERB } from "./wire-mesh-transport.js";
+
+/** Extracts and validates the carried MeshMessage from an incoming FRAME_VERB command. Returns undefined for anything that isn't a well-formed frame -- an unrecognised or malformed payload is dropped, not thrown. Exported for WireMeshTransport's own quarantine-gate pre-approval check (introduce/connect_request detection), the one place outside this router that still needs to decode a legacy frame directly. */
+export function extractMessage(
+  command: IncomingManageRequest["command"],
+): MeshMessage | undefined {
+  if (command.verb !== FRAME_VERB) return undefined;
+  const params: unknown = command.params;
+  if (typeof params !== "object" || params === null) return undefined;
+  if (!("message" in params)) return undefined;
+  const message: unknown = params.message;
+  return isMeshMessage(message) ? message : undefined;
+}
+
+/** Routes an already-decoded legacy MeshMessage to the matching TransportEvents callback -- moved verbatim from WireMeshTransport's own former route() method. */
+function routeLegacyMessage(
+  handle: ConnectionHandle,
+  message: MeshMessage,
+  events: TransportEvents,
+): void {
+  switch (message.method) {
+    case "introduce": {
+      events.onIntroduction(handle, {
+        peerId: handle.id,
+        dataPort: message.dataPort,
+      });
+      return;
+    }
+    case "peer_list": {
+      events.onPeerList(message.peers);
+      return;
+    }
+    case "peer_joined": {
+      events.onPeerJoined(message.peer);
+      return;
+    }
+    case "become_coordinator": {
+      events.onBecomeCoordinator(message.peerList);
+      return;
+    }
+    case "connect_request": {
+      // Only ever reaches here if a session was somehow promoted without going through WireMeshTransport's own consumeQuarantined handling of it -- can't happen given every requiresApproval accept path routes through consumeQuarantined first, kept here only so an unrecognised-in-context method fails closed rather than falling to the default onMessage case below.
+      return;
+    }
+    default: {
+      events.onMessage(handle, message);
+    }
+  }
+}
+
+/** Reads params.verb from an incoming command's params, or undefined if it isn't a plain object with a string verb field. */
+function extractParamsVerb(params: unknown): string | undefined {
+  if (typeof params !== "object" || params === null) return undefined;
+  if (!("verb" in params)) return undefined;
+  return typeof params.verb === "string" ? params.verb : undefined;
+}
+
+/** Handles one already-verified-and-approved incoming request, given its authenticated connection handle. Registered per params.verb (room.send, room.join, ...), never per command.verb (the shared room:member capability every ordinary membership verb rides under) -- see this file's own header comment. */
+export type RoomVerbHandler = (
+  request: IncomingManageRequest,
+  handle: ConnectionHandle,
+) => Promise<ManageOutcome>;
+
+export interface RoomRouterOptions {
+  /** The legacy TransportEvents callbacks, still the only path for anything core/room doesn't yet have real semantics for. */
+  events: TransportEvents;
+  /** Room-verb handlers, keyed by params.verb. Empty in P3.3 -- each later phase registers the verbs it implements. */
+  handlers?: Partial<Record<string, RoomVerbHandler>>;
+}
+
+export interface RoomRouter {
+  /** Handles one already-received request. Exported for direct unit testing; drainSession below is the thin per-session loop wrapper real callers use. */
+  handleRequest: (
+    request: IncomingManageRequest,
+    handle: ConnectionHandle,
+  ) => Promise<void>;
+  /** Consumes one session's incomingManageRequests until it ends, dispatching each request via handleRequest. Becomes the single consumer of that iterable from this point on -- the caller must not also iterate the same session's incomingManageRequests itself once this is called. */
+  drainSession: (
+    session: AcceptedMeshSession,
+    handle: ConnectionHandle,
+  ) => void;
+}
+
+export function createRoomRouter(options: RoomRouterOptions): RoomRouter {
+  async function handleRequest(
+    request: IncomingManageRequest,
+    handle: ConnectionHandle,
+  ): Promise<void> {
+    if (request.command.verb === FRAME_VERB) {
+      const message = extractMessage(request.command);
+      if (message !== undefined) {
+        routeLegacyMessage(handle, message, options.events);
+      }
+      await request.respond({ result: "ok" }).catch(() => undefined);
+      return;
+    }
+
+    const verb = extractParamsVerb(request.command.params);
+    const handler = verb !== undefined ? options.handlers?.[verb] : undefined;
+    if (handler === undefined) {
+      await request
+        .respond({ result: "error", code: "unsupported_verb" })
+        .catch(() => undefined);
+      return;
+    }
+    const outcome = await handler(request, handle);
+    await request.respond(outcome).catch(() => undefined);
+  }
+
+  return {
+    handleRequest,
+    drainSession(session, handle) {
+      void (async () => {
+        for await (const request of session.incomingManageRequests) {
+          await handleRequest(request, handle);
+        }
+      })();
+    },
+  };
+}

--- a/src/core/wire-mesh-transport.ts
+++ b/src/core/wire-mesh-transport.ts
@@ -24,7 +24,6 @@ import type {
   Listener,
   Transport,
 } from "wire-mesh-core/ports/transport";
-import { isMeshMessage } from "./wire-protocol.js";
 import type { MeshMessage, PeerInfo } from "./wire-protocol.js";
 import type {
   ConnectionHandle,
@@ -36,6 +35,11 @@ import type {
 import type { PeerIdentity } from "./identity.js";
 import { toIdentityPort } from "./wire-mesh-identity.js";
 import { nanoid } from "./nanoid.js";
+import {
+  createRoomRouter,
+  extractMessage,
+  type RoomRouter,
+} from "./room-router.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -60,16 +64,6 @@ export const FRAME_SCOPE: Readonly<CapabilityScope> = {
 
 export function buildCommand(message: MeshMessage): ManageCommand {
   return { verb: FRAME_VERB, params: { message } };
-}
-
-/** Extracts and validates the carried MeshMessage from an incoming command. Returns undefined for anything that isn't a well-formed frame -- an unrecognised or malformed payload is dropped, not thrown, the same tolerance TlsTransport's own frame parser already extends to input it can't make sense of. */
-function extractMessage(command: ManageCommand): MeshMessage | undefined {
-  if (command.verb !== FRAME_VERB) return undefined;
-  const params: unknown = command.params;
-  if (typeof params !== "object" || params === null) return undefined;
-  if (!("message" in params)) return undefined;
-  const message: unknown = params.message;
-  return isMeshMessage(message) ? message : undefined;
 }
 
 /** Reads the port a listener actually bound, from its own reported address -- never the port it was asked to bind, which is 0 whenever the caller wanted the OS to assign a free one. Bookkeeping that stores the requested port instead silently reports 0 for every OS-assigned listener. */
@@ -153,6 +147,9 @@ export class WireMeshTransport implements MeshTransport {
   // -- connect_request frames awaiting a human accept/reject decision, keyed by the requester's device-id hex --
   private pendingConnections = new Map<string, PendingConnection>();
 
+  // -- The single consumer of every approved session's incomingManageRequests, once quarantine (if any) is past. Owns verb dispatch (the legacy opaque frame, plus whichever real core/room verbs later phases register handlers for) -- this transport itself no longer decodes or routes a MeshMessage at all beyond handing a session off here.
+  private readonly roomRouter: RoomRouter;
+
   constructor(events: TransportEvents, identity: Readonly<PeerIdentity>) {
     this.events = events;
     this.wireTransport = createTlsTransport({
@@ -160,6 +157,7 @@ export class WireMeshTransport implements MeshTransport {
       privateKeyPem: identity.privateKey,
     });
     this.identityReady = toIdentityPort(identity);
+    this.roomRouter = createRoomRouter({ events });
   }
 
   // -- Public getters --
@@ -241,7 +239,7 @@ export class WireMeshTransport implements MeshTransport {
       for await (const request of session.incomingManageRequests) {
         if (this.shutDown) break;
         if (approved) {
-          await this.dispatchIncoming(request, handle);
+          await this.roomRouter.handleRequest(request, handle);
           continue;
         }
         const message = extractMessage(request.command);
@@ -251,7 +249,10 @@ export class WireMeshTransport implements MeshTransport {
         }
         if (message.method === "introduce") {
           this.trackSession(handle.id, session);
-          this.route(handle, message);
+          this.events.onIntroduction(handle, {
+            peerId: handle.id,
+            dataPort: message.dataPort,
+          });
           await request.respond({ result: "ok" }).catch(() => undefined);
           approved = true;
           continue;
@@ -294,61 +295,12 @@ export class WireMeshTransport implements MeshTransport {
     })();
   }
 
+  /** Delegates the whole post-approval drain loop to roomRouter -- this transport no longer decodes or routes a MeshMessage itself, only hands the session off. */
   private consumeIncoming(
     session: AcceptedMeshSession,
     handle: ConnectionHandle,
   ): void {
-    void (async () => {
-      for await (const request of session.incomingManageRequests) {
-        if (this.shutDown) break;
-        await this.dispatchIncoming(request, handle);
-      }
-    })();
-  }
-
-  private async dispatchIncoming(
-    request: IncomingManageRequest,
-    handle: ConnectionHandle,
-  ): Promise<void> {
-    const message = extractMessage(request.command);
-    if (message === undefined) {
-      await request.respond({ result: "ok" }).catch(() => undefined);
-      return;
-    }
-    this.route(handle, message);
-    await request.respond({ result: "ok" }).catch(() => undefined);
-  }
-
-  /** Routes an already-decoded MeshMessage to the matching TransportEvents callback -- the same dispatch regardless of which listener (coordinator or data) accepted the connection it arrived on, since the message's own method, not the port it arrived on, is what determines meaning. */
-  private route(handle: ConnectionHandle, message: MeshMessage): void {
-    switch (message.method) {
-      case "introduce": {
-        this.events.onIntroduction(handle, {
-          peerId: handle.id,
-          dataPort: message.dataPort,
-        });
-        return;
-      }
-      case "peer_list": {
-        this.events.onPeerList(message.peers);
-        return;
-      }
-      case "peer_joined": {
-        this.events.onPeerJoined(message.peer);
-        return;
-      }
-      case "become_coordinator": {
-        this.events.onBecomeCoordinator(message.peerList);
-        return;
-      }
-      case "connect_request": {
-        // Only ever reaches route() if a session was somehow promoted without going through consumeQuarantined's own handling of it -- can't happen given every requiresApproval accept path routes through consumeQuarantined first, kept here only so an unrecognised-in-context method fails closed rather than falling to the default onMessage case below.
-        return;
-      }
-      default: {
-        this.events.onMessage(handle, message);
-      }
-    }
+    this.roomRouter.drainSession(session, handle);
   }
 
   private watchForDisconnect(

--- a/src/test/room-router.test.ts
+++ b/src/test/room-router.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import type { IncomingManageRequest } from "wire-mesh-core/domain/mesh-session";
+import type { ManageOutcome } from "wire-mesh-core/domain/mesh-session";
+import { FRAME_VERB, buildCommand } from "../core/wire-mesh-transport.js";
+import { createRoomRouter } from "../core/room-router.js";
+import type { ConnectionHandle, TransportEvents } from "../core/transport.js";
+
+const TEST_HANDLE: ConnectionHandle = { id: "a".repeat(64) };
+
+function fakeEvents(): TransportEvents {
+  return {
+    onMessage: mock.fn(),
+    onIntroduction: mock.fn(),
+    onConnectionRequest: mock.fn(),
+    onPeerConnected: mock.fn(),
+    onPeerDisconnected: mock.fn(),
+    onPeerList: mock.fn(),
+    onPeerJoined: mock.fn(),
+    onBecomeCoordinator: mock.fn(),
+    onError: mock.fn(),
+  };
+}
+
+function fakeRequest(
+  command: IncomingManageRequest["command"],
+  token?: IncomingManageRequest["token"],
+): { request: IncomingManageRequest; responses: ManageOutcome[] } {
+  const responses: ManageOutcome[] = [];
+  const request: IncomingManageRequest = {
+    requestId: 1,
+    command,
+    scope: { kind: "room" },
+    ...(token !== undefined ? { token } : {}),
+    respond: async (outcome: ManageOutcome): Promise<void> => {
+      responses.push(outcome);
+    },
+  };
+  return { request, responses };
+}
+
+describe("createRoomRouter", () => {
+  it("routes a legacy FRAME_VERB command to events.onMessage", async () => {
+    const events = fakeEvents();
+    const router = createRoomRouter({ events });
+    const { request, responses } = fakeRequest(
+      buildCommand({ method: "peer_list", peers: [] }),
+    );
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.equal(
+      (
+        events.onPeerList as unknown as ReturnType<typeof mock.fn>
+      ).mock.callCount(),
+      1,
+    );
+    assert.deepEqual(responses, [{ result: "ok" }]);
+  });
+
+  it("routes an otherwise-well-formed FRAME_VERB payload with no recognised case to the onMessage catch-all", async () => {
+    const events = fakeEvents();
+    const router = createRoomRouter({ events });
+    // A wire payload shaped like a MeshMessage but naming a method no case in routeLegacyMessage's switch recognises -- e.g. from a peer running a newer build. isMeshMessage's own runtime check only requires a string method field, deliberately looser than the closed MeshMessage type, so this constructs the command directly rather than through buildCommand (which requires a real MeshMessage at compile time).
+    const { request, responses } = fakeRequest({
+      verb: FRAME_VERB,
+      params: { message: { method: "not-a-real-method" } },
+    });
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.equal(
+      (
+        events.onMessage as unknown as ReturnType<typeof mock.fn>
+      ).mock.callCount(),
+      1,
+    );
+    assert.deepEqual(responses, [{ result: "ok" }]);
+  });
+
+  it("responds ok without routing anything for a FRAME_VERB payload with no message field at all", async () => {
+    const events = fakeEvents();
+    const router = createRoomRouter({ events });
+    const { request, responses } = fakeRequest({
+      verb: FRAME_VERB,
+      params: {},
+    });
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.equal(
+      (
+        events.onMessage as unknown as ReturnType<typeof mock.fn>
+      ).mock.callCount(),
+      0,
+    );
+    assert.deepEqual(responses, [{ result: "ok" }]);
+  });
+
+  it("dispatches a registered room verb to its own handler", async () => {
+    const events = fakeEvents();
+    const handled: unknown[] = [];
+    const router = createRoomRouter({
+      events,
+      handlers: {
+        "room.send": async (request) => {
+          handled.push(request.command.params);
+          return { result: "ok" };
+        },
+      },
+    });
+    const { request, responses } = fakeRequest({
+      verb: "room:member",
+      params: { verb: "room.send", text: "hi" },
+    });
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.deepEqual(handled, [{ verb: "room.send", text: "hi" }]);
+    assert.deepEqual(responses, [{ result: "ok" }]);
+  });
+
+  it("refuses an unregistered room verb with unsupported_verb", async () => {
+    const events = fakeEvents();
+    const router = createRoomRouter({ events });
+    const { request, responses } = fakeRequest({
+      verb: "room:member",
+      params: { verb: "room.send", text: "hi" },
+    });
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.equal(responses.length, 1);
+    assert.deepEqual(responses[0], {
+      result: "error",
+      code: "unsupported_verb",
+    });
+  });
+
+  it("refuses a verb this domain has never heard of with unsupported_verb", async () => {
+    const events = fakeEvents();
+    const router = createRoomRouter({ events });
+    const { request, responses } = fakeRequest({
+      verb: "exec:pty",
+      params: { verb: "exec.list" },
+    });
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.deepEqual(responses, [
+      { result: "error", code: "unsupported_verb" },
+    ]);
+  });
+
+  it("refuses a params object with no verb field at all", async () => {
+    const events = fakeEvents();
+    const router = createRoomRouter({ events });
+    const { request, responses } = fakeRequest({
+      verb: "room:member",
+      params: {},
+    });
+
+    await router.handleRequest(request, TEST_HANDLE);
+
+    assert.deepEqual(responses, [
+      { result: "error", code: "unsupported_verb" },
+    ]);
+  });
+});


### PR DESCRIPTION
Part of #48 (P3.3: the verb router).

Moves WireMeshTransport's dispatch logic (decode a FRAME_VERB command, route it to the matching TransportEvents callback) into a new `room-router.ts` module: `createRoomRouter` owns one drain loop per session and dispatches on `params.verb` rather than the outer `command.verb` (which is always the shared `room:member` capability every ordinary membership verb rides under, per core/room's own wire shape).

The legacy FRAME_VERB path is preserved unchanged as a fallback; a registered room-verb handler takes priority over it, and anything else — an unrecognised verb, or a room verb no handler is registered for yet — gets `unsupported_verb` rather than being silently dropped. No handlers are registered yet in this phase; later phases (P3.4 admission, P3.5 fan-out, P3.6 state-sync, P3.7 kick) register their own verbs here without touching the transport again.

`extractMessage` moves into the router too but stays exported, since `WireMeshTransport`'s own pre-approval quarantine gate (`consumeQuarantined`) still needs to decode a legacy frame directly to detect `introduce`/`connect_request` before a session is trusted.