### PR TITLE
feat(core): mint and persist the room owner's own room:member grant

### DIFF
--- a/src/bridges/claude-code/channel.ts
+++ b/src/bridges/claude-code/channel.ts
@@ -157,7 +157,7 @@ export async function run(): Promise<void> {
     harness: "claude-code",
     cwd: process.cwd(),
   };
-  const { store, tool } = createBridgeMesh(identitySlot);
+  const { store, tool } = await createBridgeMesh(identitySlot);
   let agentId: string | undefined;
 
   const claudeCodePid = findClaudeCodePid();

--- a/src/bridges/codex/tool.ts
+++ b/src/bridges/codex/tool.ts
@@ -29,7 +29,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export async function run(): Promise<void> {
   // Persistent identity for this slot: a stable device-id means the agent ID survives restarts, so peers can keep targeting us. The stdio server has no graceful shutdown hook; a stale lock self-heals via the pid probe.
   const identitySlot: IdentitySlot = { harness: "codex", cwd: process.cwd() };
-  const { store, tool } = createBridgeMesh(identitySlot);
+  const { store, tool } = await createBridgeMesh(identitySlot);
   let agentId: string | undefined;
 
   const mcp = new McpServer(

--- a/src/bridges/mcp/index.ts
+++ b/src/bridges/mcp/index.ts
@@ -29,7 +29,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export async function run(): Promise<void> {
   // Persistent identity for this slot: a stable device-id means the agent ID survives restarts, so peers can keep targeting us. The stdio server has no graceful shutdown hook; a stale lock self-heals via the pid probe.
   const identitySlot: IdentitySlot = { harness: "mcp", cwd: process.cwd() };
-  const { store, tool } = createBridgeMesh(identitySlot);
+  const { store, tool } = await createBridgeMesh(identitySlot);
   let agentId: string | undefined;
 
   const mcp = new McpServer(

--- a/src/bridges/opencode/plugin.ts
+++ b/src/bridges/opencode/plugin.ts
@@ -19,7 +19,6 @@ import { nanoid } from "../../core/nanoid.js";
 
 // Persistent identity for this slot: a stable device-id means the agent ID survives restarts, so peers can keep targeting us. A plugin unload has no hook here; a stale lock self-heals via the pid probe.
 const identitySlot: IdentitySlot = { harness: "opencode", cwd: process.cwd() };
-const { store } = createBridgeMesh(identitySlot);
 
 // Minimal interface for the OpenCode SDK client we actually use
 interface OpenCodeClient {
@@ -55,6 +54,7 @@ export const AgentCommsPlugin = async (opts: {
   }
   const client = opts.client;
 
+  const { store } = await createBridgeMesh(identitySlot);
   await store.init();
   await tryStartWebServer();
 

--- a/src/bridges/pi/index.ts
+++ b/src/bridges/pi/index.ts
@@ -19,7 +19,7 @@ import { Type } from "typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 
 import {
-  createBridgeMesh,
+  createBridgeMeshSync,
   buildAction,
   ensureProjectRoom,
   ensureRegistered,
@@ -44,7 +44,7 @@ function getWebPort(handle: WebServerHandle): number | undefined {
 export default function (pi: ExtensionAPI) {
   // Persistent identity for this slot: a stable device-id means the agent ID survives restarts, so peers can keep targeting us
   const identitySlot: IdentitySlot = { harness: "pi", cwd: process.cwd() };
-  const { store, tool } = createBridgeMesh(identitySlot);
+  const { store, tool, attachIdentity } = createBridgeMeshSync(identitySlot);
 
   let agentId: string | undefined;
   let webHandle: WebServerHandle | undefined;
@@ -122,6 +122,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     uiCtx = ctx.ui;
 
+    await attachIdentity();
     await store.init();
     meshReady = store.connected;
 

--- a/src/bridges/user/controller.ts
+++ b/src/bridges/user/controller.ts
@@ -30,7 +30,8 @@ import type {
 // ---------------------------------------------------------------------------
 
 export class ChatController extends EventEmitter {
-  private store: MeshStore;
+  // Assigned either by init() (this controller owns its identity, the createBridgeMesh path) or by fromExisting() (it wraps an already-built store) -- always populated before any other method runs, definite-assignment-asserted the same way ctx already was.
+  private store!: MeshStore;
   /** Set only when this controller owns its persisted identity (standalone mode). */
   private ownedIdentitySlot: IdentitySlot | undefined;
 
@@ -38,26 +39,15 @@ export class ChatController extends EventEmitter {
   get meshStore(): MeshStore {
     return this.store;
   }
-  private tool: CommsTool;
+  private tool!: CommsTool;
   private ctx!: CommsContext;
   private currentRoom: string | undefined;
 
   constructor(
     private userName: string,
-    coordinatorPort?: number,
+    private coordinatorPort?: number,
   ) {
     super();
-    // Persistent identity for the web user's slot so the chat identity survives relaunches of the standalone web CLI
-    const identitySlot: IdentitySlot = { harness: "user", cwd: process.cwd() };
-    this.ownedIdentitySlot = identitySlot;
-    const { store, tool } = createBridgeMesh(identitySlot, coordinatorPort);
-    this.store = store;
-    this.tool = tool;
-
-    // Push delivery events to UIs
-    this.store.onDelivery = (_agentId: string, event: DeliveryEvent) => {
-      this.emit("message", event);
-    };
   }
 
   /**
@@ -83,6 +73,21 @@ export class ChatController extends EventEmitter {
   }
 
   async init(): Promise<void> {
+    // Persistent identity for the web user's slot so the chat identity survives relaunches of the standalone web CLI
+    const identitySlot: IdentitySlot = { harness: "user", cwd: process.cwd() };
+    this.ownedIdentitySlot = identitySlot;
+    const { store, tool } = await createBridgeMesh(
+      identitySlot,
+      this.coordinatorPort,
+    );
+    this.store = store;
+    this.tool = tool;
+
+    // Push delivery events to UIs
+    this.store.onDelivery = (_agentId: string, event: DeliveryEvent) => {
+      this.emit("message", event);
+    };
+
     await this.store.init();
 
     const reg = await ensureRegistered({

--- a/src/core/bridge-mesh.ts
+++ b/src/core/bridge-mesh.ts
@@ -2,28 +2,60 @@
  * Shared bootstrap for a bridge's own mesh participation: load or create this bridge's persisted identity, construct a MeshStore wired to WireMeshTransport, and build the CommsTool that sits on top of it. Every bridge previously repeated this same four-line block against TlsTransport/identity.fingerprint directly; this factory is the single place that wiring lives now, so the substrate a bridge runs on is a one-line change here rather than six repeated ones.
  *
  * peerId is deviceIdToHex(identity.deviceId), not identity.fingerprint -- WireMeshTransport's own session bookkeeping is keyed by device-id, so MeshStore's own notion of "this peer's id" has to be the same value for the two to correlate. Every existing agent id changes the first time a bridge starts through this factory: there is no migration path, since the value is a hash of genuinely different bytes (device-id is SHA-256(raw public key); fingerprint is SHA-256(certificate DER)) -- a hard cutover, already established as correct when identity.ts first grew deviceId, not relitigated here.
+ *
+ * Split into a synchronous half (wireBridgeMesh) and an async half (attachMintingIdentity, wrapping toIdentityPort's WebCrypto import) because deriving the IdentityPort MeshStore mints room-membership grants against is unavoidably async, but not every bridge entry point can await one inline -- a plugin loader that calls its extension's default export synchronously (e.g. pi's own) cannot. createBridgeMeshSync exposes both halves for that case, deferring attachIdentity() to wherever the bridge's own lifecycle first has an async context (its own session-start hook), which is always well before the bridge does anything identity-dependent like createRoom. createBridgeMesh remains the convenient all-in-one for every bridge whose own entry point is already async.
  */
 
 import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
+import { createSystemClock } from "wire-mesh-core/adapters/system-clock";
 import { MeshStore } from "./mesh-store.js";
 import { CommsTool } from "./tool.js";
 import { WireMeshTransport } from "./wire-mesh-transport.js";
 import { loadOrCreateIdentity } from "./identity-store.js";
 import type { IdentitySlot } from "./identity-store.js";
+import { toIdentityPort } from "./wire-mesh-identity.js";
 
 export interface BridgeMesh {
   store: MeshStore;
   tool: CommsTool;
 }
 
-export function createBridgeMesh(
+export interface BridgeMeshSync extends BridgeMesh {
+  /** Derives and wires this store's IdentityPort (the collaborator createRoom and every other identity-using method require). Must be awaited before any such method runs; safe to call from the bridge's own first async lifecycle hook rather than its (necessarily synchronous) entry point. */
+  attachIdentity: () => Promise<void>;
+}
+
+/** The synchronous half of bridge construction: everything loadOrCreateIdentity's own synchronous key material makes possible. Use this directly only when the calling entry point cannot await inline (see this file's own header comment); every other caller should use createBridgeMesh below. */
+export function createBridgeMeshSync(
   slot: Readonly<IdentitySlot>,
   coordinatorPort?: number,
-): BridgeMesh {
+): BridgeMeshSync {
   const identity = loadOrCreateIdentity(slot);
   const store = new MeshStore(coordinatorPort);
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
   store.setTransport(new WireMeshTransport(store.events, identity));
   const tool = new CommsTool(store, store.discovery);
+  return {
+    store,
+    tool,
+    attachIdentity: async () => {
+      store.setIdentity({
+        identity: await toIdentityPort(identity),
+        clock: createSystemClock(),
+        slot,
+      });
+    },
+  };
+}
+
+export async function createBridgeMesh(
+  slot: Readonly<IdentitySlot>,
+  coordinatorPort?: number,
+): Promise<BridgeMesh> {
+  const { store, tool, attachIdentity } = createBridgeMeshSync(
+    slot,
+    coordinatorPort,
+  );
+  await attachIdentity();
   return { store, tool };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,8 +9,8 @@ export type { CommsStore } from "./comms-store.js";
 export { FileStore, CommsError } from "./store.js";
 export { MeshStore } from "./mesh-store.js";
 export { CommsTool } from "./tool.js";
-export { createBridgeMesh } from "./bridge-mesh.js";
-export type { BridgeMesh } from "./bridge-mesh.js";
+export { createBridgeMesh, createBridgeMeshSync } from "./bridge-mesh.js";
+export type { BridgeMesh, BridgeMeshSync } from "./bridge-mesh.js";
 export type { CommsContext, CommsResult } from "./tool.js";
 export {
   buildAction,

--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -26,6 +26,13 @@ import { TailscaleDiscoveryBackend } from "./discovery-tailscale.js";
 import { FederationManager } from "./federation.js";
 import type { FedLink } from "./federation.js";
 import { getCertificateFingerprint } from "./identity.js";
+import { deviceIdFromHex } from "wire-mesh-core/domain/device-id";
+import { mintCapabilityToken } from "wire-mesh-core/domain/tokens";
+import type { IdentityPort } from "wire-mesh-core/ports/identity";
+import type { Clock } from "wire-mesh-core/ports/clock";
+import { saveRoomToken } from "./identity-store.js";
+import type { IdentitySlot } from "./identity-store.js";
+import { randomTokenId } from "./token-id.js";
 import type { MeshMessage, MeshStatePatch, PeerInfo } from "./wire-protocol.js";
 import type {
   ConnectionHandle,
@@ -55,6 +62,18 @@ import type { ListenerInfo, ListenerPolicy } from "./transport.js";
 
 const DEFAULT_COORDINATOR_PORT = 19876;
 const COORDINATOR_HOST = "127.0.0.1";
+
+/** The identity/clock/persistence collaborators MeshStore mints and persists room-membership grants against. Set via setIdentity(), mirroring the transport's own setTransport() contract. */
+export interface MeshStoreIdentity {
+  identity: IdentityPort;
+  clock: Clock;
+  slot: IdentitySlot;
+}
+
+/**
+ * Lifetime of a freshly minted room:member grant (owner root grant or member join/invite grant alike). Deliberately generous rather than the "short expires, periodic re-issue" pattern the design calls for to bound kick-convergence to gossip-independent expiry -- that re-issue mechanism is P3.7's own deliverable (riding room.members refreshes), and shipping a short expiry before it exists would let ordinary grants go stale with nothing to renew them. 30 days comfortably outlives any realistic room lifetime for now; P3.7 tightens this once re-issue-on-refresh lands.
+ */
+const ROOM_TOKEN_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Bound on pending delivery events held per target agent. Events beyond the
@@ -103,6 +122,7 @@ export class MeshStore implements CommsStore {
   private identityCache = new Map<string, { id: string }>();
 
   private transport: MeshTransport | undefined;
+  private storeIdentity: MeshStoreIdentity | undefined;
   private peerInfo = new Map<string, PeerInfo>();
   private staleCheckTimer: ReturnType<typeof setInterval> | undefined;
   private isShutDown = false;
@@ -195,6 +215,21 @@ export class MeshStore implements CommsStore {
       );
     }
     return this.transport;
+  }
+
+  /** Sets the identity/clock/slot this store mints and persists room-membership grants against. Must be called before createRoom() or any other identity-using method, mirroring setTransport()'s own contract. */
+  setIdentity(identity: MeshStoreIdentity): void {
+    this.storeIdentity = identity;
+  }
+
+  /** The set identity, or throws if setIdentity() hasn't been called yet -- the single place every identity-using method reads through, mirroring requireTransport() above. */
+  private requireIdentity(): MeshStoreIdentity {
+    if (this.storeIdentity === undefined) {
+      throw new Error(
+        "MeshStore: no identity set; call setIdentity() before using the store",
+      );
+    }
+    return this.storeIdentity;
   }
 
   // -----------------------------------------------------------------------
@@ -1143,6 +1178,32 @@ export class MeshStore implements CommsStore {
   // CommsStore — Rooms
   // -----------------------------------------------------------------------
 
+  /**
+   * Mints and persists the room owner's own self-signed room:member grant: issuer = bearer = owner, no parent, delegationsRemaining: 0. This is deliberately NOT the parent every later member grant chains through -- a delegations-remaining: 0 parent cannot mint any child at all (mintCapabilityToken refuses a child whose own delegationsRemaining isn't strictly less than its parent's, and there is no value less than 0), so a later join/invite grant is its own independent, parent-less, owner-issued root-level token instead (still satisfying the "chain roots at the path's own owner" obligation, since rootIssuer is just the token's own issuer when it carries no parent). This root grant exists purely so the owner has a token to present for its own room actions, uniformly with every other member, per the design's own "every code path that checks membership does the same thing regardless of who it is checking" reasoning.
+   */
+  private async mintOwnerRootGrant(
+    roomPath: string,
+    owner: string,
+  ): Promise<void> {
+    const { identity, clock, slot } = this.requireIdentity();
+    const verdict = await mintCapabilityToken({
+      identity,
+      clock,
+      tokenId: randomTokenId(),
+      bearer: deviceIdFromHex(owner),
+      capability: "room:member",
+      scope: { kind: "room", path: roomPath },
+      expires: clock.now() + ROOM_TOKEN_LIFETIME_MS,
+      delegationsRemaining: 0,
+    });
+    if (!verdict.ok) {
+      throw new Error(
+        `MeshStore: failed to mint room owner grant for ${roomPath}: ${verdict.reason}`,
+      );
+    }
+    saveRoomToken(slot, roomPath, verdict.token);
+  }
+
   async createRoom(opts: {
     name: string;
     type: RoomType;
@@ -1156,6 +1217,9 @@ export class MeshStore implements CommsStore {
     const id = ownerNamedRoomPath(opts.owner, localName);
     if (this.rooms.has(id))
       throw new CommsError(`Room ${id} already exists`, "ROOM_EXISTS");
+
+    // Every room creation this store performs is local: opts.owner is always this bridge's own identity (create_room's caller passes ctx.agentId, and one bridge process is one agent is one device), so minting the owner's own root grant here always signs under the identity this store was wired with, never someone else's.
+    await this.mintOwnerRootGrant(id, opts.owner);
 
     const room: Room = {
       id,

--- a/src/core/token-id.ts
+++ b/src/core/token-id.ts
@@ -1,0 +1,6 @@
+/** Generates a random token-id: tokens.cddl defines token-id as an arbitrary-length bstr, and 16 random bytes (128 bits) is the conventional size for an unguessable identifier, matching a UUIDv4's own random payload. */
+export function randomTokenId(): Uint8Array<ArrayBuffer> {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}

--- a/src/test/approval.integration.test.ts
+++ b/src/test/approval.integration.test.ts
@@ -53,9 +53,9 @@ describe("connection approval", () => {
 
     // Set up coordinator (store A)
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     const storeB = new MeshStore(portB);
-    wireTestTransport(storeB);
+    await wireTestTransport(storeB);
     try {
       const receivedRequests: Extract<
         DeliveryEvent,
@@ -128,9 +128,9 @@ describe("connection approval", () => {
     const portB = await uniquePort();
 
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     const storeB = new MeshStore(portB);
-    wireTestTransport(storeB);
+    await wireTestTransport(storeB);
     try {
       const receivedRequests: Extract<
         DeliveryEvent,
@@ -207,9 +207,9 @@ describe("connection approval", () => {
     const portB = await uniquePort();
 
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     const storeB = new MeshStore(portB);
-    wireTestTransport(storeB);
+    await wireTestTransport(storeB);
     try {
       const receivedRequests: Extract<
         DeliveryEvent,
@@ -280,9 +280,9 @@ describe("connection approval", () => {
     const portB = await uniquePort();
 
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     const storeB = new MeshStore(portB);
-    wireTestTransport(storeB);
+    await wireTestTransport(storeB);
     try {
       storeA.onDelivery = () => {};
       await storeA.init();
@@ -364,9 +364,9 @@ describe("connection approval", () => {
     const portB = await uniquePort();
 
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     const storeB = new MeshStore(portB);
-    wireTestTransport(storeB);
+    await wireTestTransport(storeB);
     try {
       storeA.onDelivery = () => {};
       await storeA.init();
@@ -516,9 +516,9 @@ describe("connection approval", () => {
     const portB = await uniquePort();
 
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     const storeB = new MeshStore(portB);
-    wireTestTransport(storeB);
+    await wireTestTransport(storeB);
     try {
       storeA.onDelivery = () => {};
       await storeA.init();
@@ -592,7 +592,7 @@ describe("connection approval", () => {
   void test("a message other than introduce/connect_request from an unapproved connection is refused, not routed", async () => {
     const portA = await uniquePort();
     const storeA = new MeshStore(portA);
-    wireTestTransport(storeA);
+    await wireTestTransport(storeA);
     try {
       await storeA.init();
       await storeA.registerAgent({

--- a/src/test/bridge-mesh.test.ts
+++ b/src/test/bridge-mesh.test.ts
@@ -25,7 +25,7 @@ function tempSlot(harness: string): IdentitySlot {
 void test("createBridgeMesh sets peerId to deviceIdToHex(identity.deviceId), not the certificate fingerprint", async () => {
   const slot = tempSlot("test-harness");
   const identity = loadOrCreateIdentity(slot);
-  const { store } = createBridgeMesh(slot);
+  const { store } = await createBridgeMesh(slot);
   try {
     assert.strictEqual(
       store.peerId,
@@ -39,7 +39,7 @@ void test("createBridgeMesh sets peerId to deviceIdToHex(identity.deviceId), not
 
 void test("createBridgeMesh wires a WireMeshTransport", async () => {
   const slot = tempSlot("test-harness");
-  const { store } = createBridgeMesh(slot);
+  const { store } = await createBridgeMesh(slot);
   try {
     // init() is the only way to prove the transport is actually usable end to end, which also confirms it's a WireMeshTransport by construction (createBridgeMesh only ever builds one).
     await store.init();
@@ -53,8 +53,8 @@ void test("createBridgeMesh passes an explicit coordinatorPort through to MeshSt
   const slotA = tempSlot("test-harness-a");
   const slotB = tempSlot("test-harness-b");
   const port = 20_900 + Math.floor(Math.random() * 100);
-  const a = createBridgeMesh(slotA, port);
-  const b = createBridgeMesh(slotB, port);
+  const a = await createBridgeMesh(slotA, port);
+  const b = await createBridgeMesh(slotB, port);
   try {
     await a.store.init();
     await b.store.init();

--- a/src/test/coordinator-socket-error.integration.test.ts
+++ b/src/test/coordinator-socket-error.integration.test.ts
@@ -23,7 +23,7 @@ const TEST_PORT = 19879;
  */
 void test("coordinator survives ECONNRESET on accepted socket", async () => {
   const store = new MeshStore(TEST_PORT);
-  wireTestTransport(store);
+  await wireTestTransport(store);
   await store.init();
 
   // Connect a raw socket to the coordinator port

--- a/src/test/create-room-mints-owner-grant.test.ts
+++ b/src/test/create-room-mints-owner-grant.test.ts
@@ -1,0 +1,62 @@
+/**
+ * createRoom must mint and persist the owner's own self-signed room:member grant, so the owner has a token to present for its own room actions uniformly with every other member (rather than being implicitly exempt from the check every other member's actions go through).
+ */
+
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import { deviceIdFromHex } from "wire-mesh-core/domain/device-id";
+import { verifyCapabilityToken } from "wire-mesh-core/domain/tokens";
+import { createSystemClock } from "wire-mesh-core/adapters/system-clock";
+import { MeshStore } from "../core/mesh-store.js";
+import { loadRoomTokens } from "../core/identity-store.js";
+import type { IdentitySlot } from "../core/identity-store.js";
+import { generateIdentity } from "../core/identity.js";
+import { toIdentityPort } from "../core/wire-mesh-identity.js";
+import { wireTestTransport } from "./test-transport.js";
+
+async function makeStore(): Promise<{ store: MeshStore; slot: IdentitySlot }> {
+  const store = new MeshStore();
+  const slot = await wireTestTransport(store);
+  return { store, slot };
+}
+
+void test("createRoom persists a self-signed room:member grant for the owner", async () => {
+  const { store, slot } = await makeStore();
+  const owner = await store.registerAgent({
+    name: "owner",
+    harness: "pi",
+    cwd: "/tmp/p",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+
+  const room = await store.createRoom({
+    name: "general",
+    type: "public",
+    owner: owner.id,
+    description: "",
+  });
+
+  const tokens = loadRoomTokens(slot);
+  const token = tokens[room.id];
+  assert.ok(token !== undefined, "expected a persisted token for the new room");
+
+  // Any IdentityPort supplies verification-only crypto primitives -- verifyCapabilityToken never trusts the caller's own identity, only the token's self-certifying issuer-key, so a throwaway identity works here exactly as well as the owner's real one.
+  const verifierIdentity = await toIdentityPort(generateIdentity());
+  const verdict = await verifyCapabilityToken(token, {
+    identity: verifierIdentity,
+    clock: createSystemClock(),
+    revocation: { isRevoked: async () => false },
+    expectedBearer: deviceIdFromHex(owner.id),
+  });
+
+  assert.ok(
+    verdict.ok,
+    `expected the owner grant to verify, got ${JSON.stringify(verdict)}`,
+  );
+  if (!verdict.ok) return;
+  assert.equal(verdict.claims.capability, "room:member");
+  assert.deepEqual(verdict.claims.scope, { kind: "room", path: room.id });
+  assert.deepEqual(verdict.rootIssuer, deviceIdFromHex(owner.id));
+});

--- a/src/test/create-room-name-sanitisation.test.ts
+++ b/src/test/create-room-name-sanitisation.test.ts
@@ -8,14 +8,14 @@ import { MeshStore } from "../core/mesh-store.js";
 import { ownerNamedRoomPath } from "../core/room-path.js";
 import { wireTestTransport } from "./test-transport.js";
 
-function makeStore(): MeshStore {
+async function makeStore(): Promise<MeshStore> {
   const store = new MeshStore();
-  wireTestTransport(store);
+  await wireTestTransport(store);
   return store;
 }
 
 void test("createRoom sanitises a name containing spaces and dots instead of throwing", async () => {
-  const store = makeStore();
+  const store = await makeStore();
   const owner = await store.registerAgent({
     name: "owner",
     harness: "pi",
@@ -37,7 +37,7 @@ void test("createRoom sanitises a name containing spaces and dots instead of thr
 });
 
 void test("createRoom's sanitised id is what getRoom must be looked up by", async () => {
-  const store = makeStore();
+  const store = await makeStore();
   const owner = await store.registerAgent({
     name: "owner",
     harness: "pi",

--- a/src/test/delivery-receipt.helper.ts
+++ b/src/test/delivery-receipt.helper.ts
@@ -63,7 +63,7 @@ async function cleanup(...stores: MeshStore[]): Promise<void> {
 async function testPushRoom(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   const deliveriesA: unknown[] = [];
   a.onDelivery = () => {
     deliveriesA.push(1);
@@ -80,7 +80,7 @@ async function testPushRoom(): Promise<void> {
   await sleep(100);
 
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   const deliveriesB: DeliveryEvent[] = [];
   b.onDelivery = (_id: string, ev: DeliveryEvent) => {
     deliveriesB.push(ev);
@@ -128,7 +128,7 @@ async function testPushRoom(): Promise<void> {
 async function testPushDm(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   const deliveriesA: unknown[] = [];
   a.onDelivery = () => {
     deliveriesA.push(1);
@@ -145,7 +145,7 @@ async function testPushDm(): Promise<void> {
   await sleep(100);
 
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   const deliveriesB: DeliveryEvent[] = [];
   b.onDelivery = (_id: string, ev: DeliveryEvent) => {
     deliveriesB.push(ev);
@@ -180,7 +180,7 @@ async function testPushDm(): Promise<void> {
 async function testDrainRoom(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   await a.init();
   await a.registerAgent({
     name: "a",
@@ -194,7 +194,7 @@ async function testDrainRoom(): Promise<void> {
 
   // B has NO onDelivery — events queue for drain
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   await b.init();
   await b.registerAgent({
     name: "b",
@@ -244,7 +244,7 @@ async function testDrainRoom(): Promise<void> {
 async function testDrainDm(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   await a.init();
   await a.registerAgent({
     name: "a",
@@ -257,7 +257,7 @@ async function testDrainDm(): Promise<void> {
   await sleep(100);
 
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   await b.init();
   await b.registerAgent({
     name: "b",
@@ -288,7 +288,7 @@ async function testDrainDm(): Promise<void> {
 async function testReadReceiptPush(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   const deliveriesA: DeliveryEvent[] = [];
   a.onDelivery = (_id: string, ev: DeliveryEvent) => {
     deliveriesA.push(ev);
@@ -305,7 +305,7 @@ async function testReadReceiptPush(): Promise<void> {
   await sleep(100);
 
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   b.onDelivery = () => {
     /* intentionally empty — dummy handler for drain delivery */
   };
@@ -347,7 +347,7 @@ async function testReadReceiptPush(): Promise<void> {
 async function testReadReceiptDrain(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   const deliveriesA: DeliveryEvent[] = [];
   a.onDelivery = (_id: string, ev: DeliveryEvent) => {
     deliveriesA.push(ev);
@@ -365,7 +365,7 @@ async function testReadReceiptDrain(): Promise<void> {
 
   // B has NO onDelivery — drain triggers markRead
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   await b.init();
   await b.registerAgent({
     name: "b",
@@ -409,7 +409,7 @@ async function testReadReceiptDrain(): Promise<void> {
 async function testReadbyArray(): Promise<void> {
   const port = await allocFreePort();
   const a = new MeshStore(port);
-  wireTestTransport(a);
+  await wireTestTransport(a);
   a.onDelivery = () => {
     /* intentionally empty — dummy handler for drain delivery */
   };
@@ -425,7 +425,7 @@ async function testReadbyArray(): Promise<void> {
   await sleep(100);
 
   const b = new MeshStore(port);
-  wireTestTransport(b);
+  await wireTestTransport(b);
   b.onDelivery = () => {
     /* intentionally empty — dummy handler for drain delivery */
   };

--- a/src/test/downtime-replay.integration.test.ts
+++ b/src/test/downtime-replay.integration.test.ts
@@ -9,14 +9,15 @@ import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
+import { createSystemClock } from "wire-mesh-core/adapters/system-clock";
 import { MeshStore } from "../core/mesh-store.js";
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
-import { generateIdentity } from "../core/identity.js";
 import {
   loadOrCreateIdentity,
   releaseIdentityLock,
   type IdentitySlot,
 } from "../core/identity-store.js";
+import { toIdentityPort } from "../core/wire-mesh-identity.js";
 import type { DeliveryEvent } from "../core/types.js";
 import type { PeerIdentity } from "../core/identity.js";
 import { ownerNamedRoomPath } from "../core/room-path.js";
@@ -29,11 +30,19 @@ interface Peer {
   deliveries: DeliveryEvent[];
 }
 
-/** A peer wired like a real bridge: WireMeshTransport, device-id peer ID. */
-function makePeer(identity: PeerIdentity): Peer {
+/** A peer wired like a real bridge: WireMeshTransport, device-id peer ID, and a persisted identity slot so createRoom can mint and persist the owner's own room:member grant. */
+async function makePeer(
+  identity: PeerIdentity,
+  slot: IdentitySlot,
+): Promise<Peer> {
   const store = new MeshStore(TEST_PORT);
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
   store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setIdentity({
+    identity: await toIdentityPort(identity),
+    clock: createSystemClock(),
+    slot,
+  });
   const deliveries: DeliveryEvent[] = [];
   return { store, deliveries };
 }
@@ -53,9 +62,14 @@ async function waitFor(
 async function main(): Promise<void> {
   const dir = fs.mkdtempSync(path.join(tmpdir(), "agent-comms-downtime-"));
   const slot: IdentitySlot = { harness: "pi", cwd: "/tmp/project", dir };
+  const slotA: IdentitySlot = {
+    harness: "claude-code",
+    cwd: "/tmp/a",
+    dir: fs.mkdtempSync(path.join(tmpdir(), "agent-comms-downtime-a-")),
+  };
 
   // A is a normal ephemeral bridge that stays up throughout.
-  const a = makePeer(generateIdentity());
+  const a = await makePeer(loadOrCreateIdentity(slotA), slotA);
   await a.store.init();
   await a.store.registerAgent({
     name: "peer-a",
@@ -76,7 +90,7 @@ async function main(): Promise<void> {
 
   // B joins with a persisted identity and becomes a room member.
   const identityB = loadOrCreateIdentity(slot);
-  const b1 = makePeer(identityB);
+  const b1 = await makePeer(identityB, slot);
   await b1.store.init();
   // Registration must wait for the TLS data connections to establish (#23).
   await sleep(300);
@@ -112,7 +126,7 @@ async function main(): Promise<void> {
     deviceIdToHex(Uint8Array.from(identityB2.deviceId)),
     deviceIdToHex(Uint8Array.from(identityB.deviceId)),
   );
-  const b2 = makePeer(identityB2);
+  const b2 = await makePeer(identityB2, slot);
   b2.store.onDelivery = (_id, ev) => {
     b2.deliveries.push(ev);
   };

--- a/src/test/downtime-replay.test.ts
+++ b/src/test/downtime-replay.test.ts
@@ -16,14 +16,14 @@ function snapshotOf(store: MeshStore): SerialisedState {
 }
 
 /** A local-only store: transport is set (registerAgent's own broadcastPatch needs one) but never started, so no ports and no flake -- the stores in these tests never actually connect. */
-function makeStore(): MeshStore {
+async function makeStore(): Promise<MeshStore> {
   const store = new MeshStore();
-  wireTestTransport(store);
+  await wireTestTransport(store);
   return store;
 }
 
 void test("events queued while the target was down replay on its first snapshot", async () => {
-  const sender = makeStore();
+  const sender = await makeStore();
   const author = await sender.registerAgent({
     name: "author",
     harness: "pi",
@@ -33,7 +33,7 @@ void test("events queued while the target was down replay on its first snapshot"
     tags: [],
   });
   // The target exists on the mesh (known to the sender) but its process is "down": modelled by only ever syncing snapshots into a future store.
-  const target = makeStore();
+  const target = await makeStore();
   const targetAgent = await target.registerAgent({
     name: "target",
     harness: "claude-code",
@@ -59,7 +59,7 @@ void test("events queued while the target was down replay on its first snapshot"
   assert.ok(pending !== undefined && pending.length > 0);
 
   // The target returns (fresh process, same agent id) and receives the sender's snapshot: the pending event must fire onDelivery.
-  const returned = makeStore();
+  const returned = await makeStore();
   const deliveries: DeliveryEvent[] = [];
   returned.onDelivery = (_id, ev) => {
     deliveries.push(ev);
@@ -96,7 +96,7 @@ void test("events queued while the target was down replay on its first snapshot"
 });
 
 void test("a queue is bounded oldest-first so downtime cannot grow it without limit", async () => {
-  const sender = makeStore();
+  const sender = await makeStore();
   const author = await sender.registerAgent({
     name: "author",
     harness: "pi",
@@ -105,7 +105,7 @@ void test("a queue is bounded oldest-first so downtime cannot grow it without li
     visibility: "visible",
     tags: [],
   });
-  const target = makeStore();
+  const target = await makeStore();
   const targetAgent = await target.registerAgent({
     name: "target",
     harness: "claude-code",
@@ -137,7 +137,7 @@ void test("a queue is bounded oldest-first so downtime cannot grow it without li
 });
 
 void test("a pending invite replays until accepted or declined", async () => {
-  const sender = makeStore();
+  const sender = await makeStore();
   const author = await sender.registerAgent({
     name: "owner",
     harness: "pi",
@@ -146,7 +146,7 @@ void test("a pending invite replays until accepted or declined", async () => {
     visibility: "visible",
     tags: [],
   });
-  const target = makeStore();
+  const target = await makeStore();
   const targetAgent = await target.registerAgent({
     name: "invitee",
     harness: "claude-code",
@@ -165,7 +165,7 @@ void test("a pending invite replays until accepted or declined", async () => {
   });
   await sender.inviteToRoom(roomId, targetAgent.id, author.id);
 
-  const returned = makeStore();
+  const returned = await makeStore();
   const deliveries: DeliveryEvent[] = [];
   returned.onDelivery = (_id, ev) => {
     deliveries.push(ev);
@@ -178,7 +178,7 @@ void test("a pending invite replays until accepted or declined", async () => {
 
   // Declined (no longer invited): the same snapshot no longer replays it.
   await sender.declineInvite(roomId, targetAgent.id, "not now");
-  const declined = makeStore();
+  const declined = await makeStore();
   const deliveries2: DeliveryEvent[] = [];
   declined.onDelivery = (_id, ev) => {
     deliveries2.push(ev);

--- a/src/test/federation.integration.test.ts
+++ b/src/test/federation.integration.test.ts
@@ -39,7 +39,7 @@ async function createMesh(
   deliveries: DeliveryEvent[];
 }> {
   const store = new MeshStore(coordinatorPort);
-  wireTestTransport(store);
+  await wireTestTransport(store);
   const deliveries: DeliveryEvent[] = [];
   store.onDelivery = (_agentId: string, event: DeliveryEvent) => {
     deliveries.push(event);

--- a/src/test/identity-restart.integration.test.ts
+++ b/src/test/identity-restart.integration.test.ts
@@ -9,15 +9,16 @@ import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
+import { createSystemClock } from "wire-mesh-core/adapters/system-clock";
 import { MeshStore } from "../core/mesh-store.js";
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
-import { generateIdentity } from "../core/identity.js";
 import type { PeerIdentity } from "../core/identity.js";
 import {
   loadOrCreateIdentity,
   releaseIdentityLock,
   type IdentitySlot,
 } from "../core/identity-store.js";
+import { toIdentityPort } from "../core/wire-mesh-identity.js";
 import type { DeliveryEvent } from "../core/types.js";
 import { ownerNamedRoomPath } from "../core/room-path.js";
 
@@ -29,11 +30,19 @@ interface Peer {
   deliveries: DeliveryEvent[];
 }
 
-/** A peer wired like a real bridge: WireMeshTransport, device-id peer ID. */
-function makePeer(identity: PeerIdentity): Peer {
+/** A peer wired like a real bridge: WireMeshTransport, device-id peer ID, and a persisted identity slot so createRoom can mint and persist the owner's own room:member grant. */
+async function makePeer(
+  identity: PeerIdentity,
+  slot: IdentitySlot,
+): Promise<Peer> {
   const store = new MeshStore(TEST_PORT);
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
   store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setIdentity({
+    identity: await toIdentityPort(identity),
+    clock: createSystemClock(),
+    slot,
+  });
   const deliveries: DeliveryEvent[] = [];
   return { store, deliveries };
 }
@@ -53,9 +62,14 @@ async function waitFor(
 async function main(): Promise<void> {
   const dir = fs.mkdtempSync(path.join(tmpdir(), "agent-comms-restart-test-"));
   const slot: IdentitySlot = { harness: "pi", cwd: "/tmp/project", dir };
+  const slotB: IdentitySlot = {
+    harness: "claude-code",
+    cwd: "/tmp/b",
+    dir: fs.mkdtempSync(path.join(tmpdir(), "agent-comms-restart-test-b-")),
+  };
 
   // Peer B is a normal ephemeral bridge that stays up throughout.
-  const b = makePeer(generateIdentity());
+  const b = await makePeer(loadOrCreateIdentity(slotB), slotB);
   await b.store.init();
   await b.store.registerAgent({
     name: "peer-b",
@@ -72,7 +86,7 @@ async function main(): Promise<void> {
 
   // First lifecycle of peer A: persistent identity, registers and creates a room.
   const identityA = loadOrCreateIdentity(slot);
-  const a1 = makePeer(identityA);
+  const a1 = await makePeer(identityA, slot);
   await a1.store.init();
   await a1.store.registerAgent({
     name: "peer-a",
@@ -104,7 +118,7 @@ async function main(): Promise<void> {
     deviceIdToHex(Uint8Array.from(identityA2.deviceId)),
     deviceIdToHex(Uint8Array.from(identityA.deviceId)),
   );
-  const a2 = makePeer(identityA2);
+  const a2 = await makePeer(identityA2, slot);
   a2.store.onDelivery = (_id, ev) => {
     a2.deliveries.push(ev);
   };

--- a/src/test/listener-policy.integration.test.ts
+++ b/src/test/listener-policy.integration.test.ts
@@ -30,7 +30,7 @@ const TEST_PORT = 19880;
 describe("listener policy", () => {
   void test("coordinator starts with a single default localhost listener", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -63,7 +63,7 @@ describe("listener policy", () => {
 
   void test("addListener creates an additional listener", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -93,7 +93,7 @@ describe("listener policy", () => {
 
   void test("removeListener removes a non-default listener", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -115,7 +115,7 @@ describe("listener policy", () => {
 
   void test("removeListener rejects removing the default listener", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -135,7 +135,7 @@ describe("listener policy", () => {
 
   void test("observe listener accepts connections but enforces policy", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -167,7 +167,7 @@ describe("listener policy", () => {
 
   void test("mesh_listeners action returns all listeners via CommsTool", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -204,7 +204,7 @@ describe("listener policy", () => {
 
   void test("mesh_interfaces action returns available network adapters", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -235,7 +235,7 @@ describe("listener policy", () => {
 
   void test("mesh_unlisten removes listener via CommsTool", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 
@@ -268,7 +268,7 @@ describe("listener policy", () => {
 
   void test("mesh_listen adds listener via CommsTool", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     try {
       await store.init();
 

--- a/src/test/mesh-e2e.integration.test.ts
+++ b/src/test/mesh-e2e.integration.test.ts
@@ -19,7 +19,7 @@ async function createStore(
   harness: string,
 ): Promise<{ store: MeshStore; tool: CommsTool; deliveries: DeliveryEvent[] }> {
   const store = new MeshStore(E2E_PORT);
-  wireTestTransport(store);
+  await wireTestTransport(store);
 
   const deliveries: DeliveryEvent[] = [];
   store.onDelivery = (_agentId: string, event: DeliveryEvent) => {

--- a/src/test/mesh-smoke.runner.ts
+++ b/src/test/mesh-smoke.runner.ts
@@ -110,14 +110,21 @@ function buildScript(name: string, actions: string): string {
     `const { MeshStore } = require("./dist/core/mesh-store.js");`,
     `const { CommsTool } = require("./dist/core/tool.js");`,
     `const { WireMeshTransport } = require("./dist/core/wire-mesh-transport.js");`,
-    `const { generateIdentity } = require("./dist/core/identity.js");`,
+    `const { loadOrCreateIdentity } = require("./dist/core/identity-store.js");`,
+    `const { toIdentityPort } = require("./dist/core/wire-mesh-identity.js");`,
     `const { deviceIdToHex } = require("wire-mesh-core/domain/device-id");`,
+    `const { createSystemClock } = require("wire-mesh-core/adapters/system-clock");`,
+    `const os = require("node:os");`,
+    `const path = require("node:path");`,
+    `const fs = require("node:fs");`,
     `function log(msg) { process.stdout.write(JSON.stringify(msg) + "\\n"); }`,
     `(async () => {`,
     `  const store = new MeshStore(${String(SMOKE_PORT)});`,
-    `  const identity = generateIdentity();`,
+    `  const slot = { harness: "smoke-${name}", cwd: "/test/${name}", dir: fs.mkdtempSync(path.join(os.tmpdir(), "agent-comms-smoke-${name}-")) };`,
+    `  const identity = loadOrCreateIdentity(slot);`,
     `  store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));`,
     `  store.setTransport(new WireMeshTransport(store.events, identity));`,
+    `  store.setIdentity({ identity: await toIdentityPort(identity), clock: createSystemClock(), slot });`,
     `  const tool = new CommsTool(store);`,
     `  const deliveries = [];`,
     `  store.onDelivery = (_id, event) => {`,
@@ -149,21 +156,33 @@ function buildScript(name: string, actions: string): string {
 // Helpers
 // -----------------------------------------------------------------------
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+const WAIT_FOR_PORT_TIMEOUT_MS = 15_000;
+const WAIT_FOR_PORT_RETRY_MS = 50;
 
+/** Retries a single connection attempt until the port accepts one or the deadline passes, rather than a single attempt after a flat sleep -- binding the port now waits on real, load-dependent work (identity load/generation, then an async WebCrypto key import for the room-token identity) before the coordinator listener opens, so a fixed pre-sleep is exactly the fragile pattern this codebase's own waitFor helpers already avoid elsewhere. */
 function waitForPort(port: number, host: string): Promise<void> {
+  const deadline = Date.now() + WAIT_FOR_PORT_TIMEOUT_MS;
   return new Promise((resolve, reject) => {
-    const socket = new net.Socket();
-    socket.connect(port, host, () => {
-      socket.destroy();
-      resolve();
-    });
-    socket.on("error", () => {
-      socket.destroy();
-      reject(new Error(`Port ${String(port)} not listening`));
-    });
+    function attempt(): void {
+      const socket = new net.Socket();
+      socket.connect(port, host, () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        if (Date.now() >= deadline) {
+          reject(
+            new Error(
+              `Port ${String(port)} not listening after ${String(WAIT_FOR_PORT_TIMEOUT_MS)}ms`,
+            ),
+          );
+          return;
+        }
+        setTimeout(attempt, WAIT_FOR_PORT_RETRY_MS);
+      });
+    }
+    attempt();
   });
 }
 
@@ -197,8 +216,7 @@ async function main(): Promise<void> {
     ].join("\n    "),
   );
 
-  // Wait for A to bind coordinator port
-  await sleep(500);
+  // Wait for A to bind coordinator port -- waitForPort itself retries until bound or its own timeout, so no fixed pre-sleep is needed.
   await waitForPort(SMOKE_PORT, SMOKE_HOST);
   console.log("  Coordinator bound on port " + String(SMOKE_PORT));
 

--- a/src/test/state-sync-convergence.test.ts
+++ b/src/test/state-sync-convergence.test.ts
@@ -12,9 +12,9 @@ import { ownerNamedRoomPath } from "../core/room-path.js";
 import { wireTestTransport } from "./test-transport.js";
 
 /** A local-only store: transport is set (registerAgent's own broadcastPatch needs one) but never started, so no ports and no flake -- the stores in these tests never actually connect. */
-function makeStore(): MeshStore {
+async function makeStore(): Promise<MeshStore> {
   const store = new MeshStore();
-  wireTestTransport(store);
+  await wireTestTransport(store);
   return store;
 }
 
@@ -23,8 +23,8 @@ function snapshotOf(store: MeshStore): SerialisedState {
 }
 
 void test("a stale holder converges when a fresher snapshot arrives", async () => {
-  const a = makeStore();
-  const b = makeStore();
+  const a = await makeStore();
+  const b = await makeStore();
   const agent = await a.registerAgent({
     name: "old-name",
     harness: "pi",
@@ -45,8 +45,8 @@ void test("a stale holder converges when a fresher snapshot arrives", async () =
 });
 
 void test("a current holder rejects a stale snapshot instead of regressing", async () => {
-  const a = makeStore();
-  const b = makeStore();
+  const a = await makeStore();
+  const b = await makeStore();
   const agent = await a.registerAgent({
     name: "old-name",
     harness: "pi",
@@ -72,8 +72,8 @@ void test("a current holder rejects a stale snapshot instead of regressing", asy
 });
 
 void test("room membership changes converge and stale member lists are rejected", async () => {
-  const a = makeStore();
-  const b = makeStore();
+  const a = await makeStore();
+  const b = await makeStore();
   const owner = await a.registerAgent({
     name: "owner",
     harness: "pi",
@@ -123,8 +123,8 @@ void test("room membership changes converge and stale member lists are rejected"
 });
 
 void test("history sync adds unseen messages and unions read receipts", async () => {
-  const a = makeStore();
-  const b = makeStore();
+  const a = await makeStore();
+  const b = await makeStore();
   const agent = await a.registerAgent({
     name: "sender",
     harness: "pi",
@@ -165,7 +165,7 @@ void test("a kick racing a concurrent join converges with the kick honoured", as
   // other records X joining, both at the same revision because they mutated
   // concurrently from the same base. Both directions of the sync must
   // converge on X being out — the leave wins an exact tie (#27).
-  const base = makeStore();
+  const base = await makeStore();
   const owner = await base.registerAgent({
     name: "owner",
     harness: "pi",
@@ -174,7 +174,7 @@ void test("a kick racing a concurrent join converges with the kick honoured", as
     visibility: "visible",
     tags: [],
   });
-  const member = makeStore();
+  const member = await makeStore();
   const x = await member.registerAgent({
     name: "x",
     harness: "claude-code",
@@ -192,8 +192,8 @@ void test("a kick racing a concurrent join converges with the kick honoured", as
   });
   await base.joinRoom(roomId, x.id);
 
-  const kicker = makeStore();
-  const joiner = makeStore();
+  const kicker = await makeStore();
+  const joiner = await makeStore();
   kicker.applyStateSync(snapshotOf(base));
   joiner.applyStateSync(snapshotOf(base));
 
@@ -214,7 +214,7 @@ void test("concurrent joins of different agents both survive the merge", async (
   // The property the old version-tie union existed to protect: two peers
   // each record a different agent joining from the same base, and the
   // merged room holds both.
-  const base = makeStore();
+  const base = await makeStore();
   const owner = await base.registerAgent({
     name: "owner",
     harness: "pi",
@@ -223,7 +223,7 @@ void test("concurrent joins of different agents both survive the merge", async (
     visibility: "visible",
     tags: [],
   });
-  const agents = makeStore();
+  const agents = await makeStore();
   const p = await agents.registerAgent({
     name: "p",
     harness: "claude-code",
@@ -249,8 +249,8 @@ void test("concurrent joins of different agents both survive the merge", async (
   });
   base.applyStateSync(snapshotOf(agents));
 
-  const holderA = makeStore();
-  const holderB = makeStore();
+  const holderA = await makeStore();
+  const holderB = await makeStore();
   holderA.applyStateSync(snapshotOf(base));
   holderB.applyStateSync(snapshotOf(base));
   await holderA.joinRoom(roomId, p.id);

--- a/src/test/test-transport.ts
+++ b/src/test/test-transport.ts
@@ -1,19 +1,41 @@
-/** Wires a real WireMeshTransport with a freshly generated identity onto a freshly constructed MeshStore -- the same setTransport() call every production bridge makes immediately after construction (via createBridgeMesh). MeshStore has no default transport, so every test that constructs one needs this (or an equivalent explicit setTransport() call) before init() or any other transport-using method runs. */
+/** Wires a real WireMeshTransport plus a persisted identity slot onto a freshly constructed MeshStore -- the same setTransport()/setIdentity() calls every production bridge makes immediately after construction (via createBridgeMesh). MeshStore has no default transport or identity, so every test that constructs one needs this (or an equivalent explicit wiring) before init(), createRoom(), or any other transport- or identity-using method runs. */
 
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
 import { WireMeshTransport } from "../core/wire-mesh-transport.js";
-import { generateIdentity } from "../core/identity.js";
 import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
+import { createSystemClock } from "wire-mesh-core/adapters/system-clock";
+import { loadOrCreateIdentity } from "../core/identity-store.js";
+import type { IdentitySlot } from "../core/identity-store.js";
+import { toIdentityPort } from "../core/wire-mesh-identity.js";
+import { nanoid } from "../core/nanoid.js";
 import type { MeshStore } from "../core/mesh-store.js";
 
-export function wireTestTransport(store: MeshStore): void {
-  const identity = generateIdentity();
+/** Wires store onto a fresh WireMeshTransport and a persisted identity slot, returning the slot so a test can inspect (or reuse) the persisted room tokens directly via loadRoomTokens(). Defaults to a throwaway temp-dir slot per call -- pass an explicit slot when a test needs the same identity to survive across more than one wireTestTransport call (e.g. simulating a restart). */
+export async function wireTestTransport(
+  store: MeshStore,
+  slot?: Readonly<IdentitySlot>,
+): Promise<IdentitySlot> {
+  const resolvedSlot: IdentitySlot = slot ?? {
+    harness: "test",
+    cwd: nanoid(8),
+    dir: fs.mkdtempSync(path.join(tmpdir(), "agent-comms-test-identity-")),
+  };
+  const identity = loadOrCreateIdentity(resolvedSlot);
   // Every real bridge sets peerId to deviceIdToHex(identity.deviceId) before wiring the transport (createBridgeMesh) -- WireMeshTransport's own session bookkeeping is keyed by device-id, so a peer's advertised ID and the identity the other side actually authenticates the connection against must be the same value, or introduction/state-sync never recognises the peer as itself.
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
   store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setIdentity({
+    identity: await toIdentityPort(identity),
+    clock: createSystemClock(),
+    slot: resolvedSlot,
+  });
   // Surface transport-level errors instead of leaving them silent — a genuine socket failure during a test run is signal worth seeing even when the test's own assertions still pass, since it can point at a real race the assertions don't happen to catch.
   store.onError = (e) => {
     console.error(`[transport error, peerId=${store.peerId}]`, e.message);
   };
+  return resolvedSlot;
 }
 
 // Generous on purpose: waitFor returns the instant its condition holds, so a long ceiling costs nothing on the happy path (a local run settles in well under a second) and only matters for the worst case -- a loaded CI runner working through a real, sequential chain of TLS handshakes (each one genuine X.509 certificate work, not instant) for the accept-flow's second connection direction, confirmed to need meaningfully more than 5s on at least one real CI run.

--- a/src/test/token-id.test.ts
+++ b/src/test/token-id.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { randomTokenId } from "../core/token-id.js";
+
+describe("randomTokenId", () => {
+  it("returns 16 bytes", () => {
+    const id = randomTokenId();
+    assert.equal(id.length, 16);
+  });
+
+  it("returns a different value on each call", () => {
+    const a = randomTokenId();
+    const b = randomTokenId();
+    assert.notDeepEqual(a, b);
+  });
+});

--- a/src/test/visibility.integration.test.ts
+++ b/src/test/visibility.integration.test.ts
@@ -74,7 +74,7 @@ describe("DiscoveryManager visibility", () => {
 describe("MeshStore visibility delegation", () => {
   void test("setVisibility delegates to discovery manager", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     await store.init();
 
     assert.equal(store.getVisibility(), "discoverable");
@@ -93,7 +93,7 @@ describe("MeshStore visibility delegation", () => {
 
   void test("setVisibility with adapter delegates per-adapter", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     await store.init();
 
     await store.setVisibility("quiet", "mdns");
@@ -111,7 +111,7 @@ describe("MeshStore visibility delegation", () => {
 describe("CommsTool visibility actions", () => {
   void test("mesh_set_visibility action sets visibility", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     await store.init();
 
     const agent = await store.registerAgent({
@@ -138,7 +138,7 @@ describe("CommsTool visibility actions", () => {
 
   void test("mesh_set_visibility with adapter sets per-adapter", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     await store.init();
 
     const agent = await store.registerAgent({
@@ -165,7 +165,7 @@ describe("CommsTool visibility actions", () => {
 
   void test("mesh_get_visibility returns current visibility", async () => {
     const store = new MeshStore(TEST_PORT);
-    wireTestTransport(store);
+    await wireTestTransport(store);
     await store.init();
 
     const agent = await store.registerAgent({


### PR DESCRIPTION
Part of #48 (P3.4: admission -- room.join, room.invite, approval).

First slice of P3.4: createRoom now mints a self-signed room:member capability token for the room's owner and persists it in the owner's identity slot, so the owner has a token to present for its own room actions uniformly with every other member, per the design doc's own "every code path that checks membership does the same thing" reasoning.

One real deviation from the design doc's literal wording, found by actually trying to implement it: the doc says a later member's join/invite grant should chain through "the owner's own root grant" as `parent`. But the doc also specifies `delegationsRemaining: 0` on that root grant -- and `mintCapabilityToken` refuses to mint any child from a parent whose `delegationsRemaining` is 0 (a child's value must be strictly less than the parent's, and there's no value less than 0). So a root grant with `delegationsRemaining: 0` can never actually be used as anyone's parent. A member's own grant is instead its own independent, parent-less, owner-issued root-level token, which satisfies the exact same verifier obligation (rootIssuer is just a token's own issuer when it carries no parent) without the contradiction.

This also required threading an `IdentityPort`/`Clock` into `MeshStore` (mirroring the existing `setTransport`/`requireTransport` pattern), which is unavoidably async since deriving an `IdentityPort` imports a WebCrypto key. `createBridgeMesh` becomes async as a result; `createBridgeMeshSync` covers the one entry point (pi's own extension loader) that can't await inline, exposing a deferred `attachIdentity()` step called from the bridge's own first async lifecycle hook.

Still to come in P3.4: minting a child grant on join/invite approval, the two-round DM consent flow, and retargeting `mesh_pending`/`mesh_accept`/`mesh_reject` from mesh admission to room admission.