### PR TITLE
feat(core): add room.join owner-side admission and the requester wire path

### DIFF
--- a/src/core/bridge-mesh.ts
+++ b/src/core/bridge-mesh.ts
@@ -33,7 +33,9 @@ export function createBridgeMeshSync(
   const identity = loadOrCreateIdentity(slot);
   const store = new MeshStore(coordinatorPort);
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
-  store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setTransport(
+    new WireMeshTransport(store.events, identity, store.roomVerbHandlers),
+  );
   const tool = new CommsTool(store, store.discovery);
   return {
     store,

--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -18,7 +18,12 @@ import * as os from "node:os";
 import { nanoid } from "./nanoid.js";
 import { CommsError } from "./store.js";
 import { normaliseWireState } from "./wire-protocol.js";
-import { dmRoomPath, ownerNamedRoomPath, slugRoomName } from "./room-path.js";
+import {
+  dmRoomPath,
+  ownerNamedRoomPath,
+  parseRoomPath,
+  slugRoomName,
+} from "./room-path.js";
 import type { SerialisedState } from "./wire-protocol.js";
 import { DiscoveryManager } from "./discovery.js";
 import { MdnsDiscoveryBackend } from "./discovery-mdns.js";
@@ -26,10 +31,20 @@ import { TailscaleDiscoveryBackend } from "./discovery-tailscale.js";
 import { FederationManager } from "./federation.js";
 import type { FedLink } from "./federation.js";
 import { getCertificateFingerprint } from "./identity.js";
-import { deviceIdFromHex } from "wire-mesh-core/domain/device-id";
+import {
+  deviceIdFromHex,
+  deviceIdToHex,
+} from "wire-mesh-core/domain/device-id";
 import { mintCapabilityToken } from "wire-mesh-core/domain/tokens";
 import type { IdentityPort } from "wire-mesh-core/ports/identity";
 import type { Clock } from "wire-mesh-core/ports/clock";
+import type {
+  IncomingManageRequest,
+  ManageOutcome,
+} from "wire-mesh-core/domain/mesh-session";
+import { roomJoinOkSchema } from "wire-mesh-core/generated/protocol";
+import type { RoomVerbHandler } from "./room-router.js";
+import { ROOM_MEMBER_CAPABILITY } from "./room-token-verification.js";
 import { saveRoomToken } from "./identity-store.js";
 import type { IdentitySlot } from "./identity-store.js";
 import { randomTokenId } from "./token-id.js";
@@ -141,6 +156,16 @@ export class MeshStore implements CommsStore {
   private pendingInboundConnections = new Map<
     string,
     { peerId: string; dataPort: number; name: string; fingerprint: string }
+  >();
+
+  // -- Pending room.join requests awaiting owner approval, keyed by `${roomPath}::${requesterId}` -- the held-open manage-request's own resolve() function is stored here so acceptRoomJoin/rejectRoomJoin can settle it in place, mirroring pendingInboundConnections' own pattern one layer up (room admission, not mesh admission).
+  private pendingRoomJoins = new Map<
+    string,
+    {
+      roomPath: string;
+      requesterId: string;
+      resolve: (decision: "accept" | "reject") => void;
+    }
   >();
 
   onDelivery:
@@ -1204,6 +1229,110 @@ export class MeshStore implements CommsStore {
     saveRoomToken(slot, roomPath, verdict.token);
   }
 
+  /**
+   * Room verb handlers this store registers with its own WireMeshTransport, keyed by params.verb per room-router.ts's own dispatch discipline. A getter (not a plain field) so every access reads through the current `this` binding without needing a constructor-time closure -- mirrors the `events` getter's own reasoning below.
+   */
+  get roomVerbHandlers(): Partial<Record<string, RoomVerbHandler>> {
+    return {
+      "room.join": (request, handle) => this.handleRoomJoin(request, handle),
+    };
+  }
+
+  /**
+   * Owner-side admission for an incoming room.join request against a named room this store owns. Holds the request open (mirroring WireMeshTransport.consumeQuarantined's own connect_request pattern) until acceptRoomJoin/rejectRoomJoin settles it, then mints the requester a fresh, independent, parent-less room:member grant -- see mintOwnerRootGrant's own comment for why this is NOT chained through the owner's root grant. Refuses outright, with no pending entry created, for anything this phase doesn't yet handle: a DM path (section 6's own two-round consent flow, not built here) or a named room this store isn't the owner of.
+   */
+  private async handleRoomJoin(
+    request: IncomingManageRequest,
+    handle: ConnectionHandle,
+  ): Promise<ManageOutcome> {
+    const roomPath = request.scope.path;
+    if (roomPath === undefined) {
+      return { result: "error", code: "missing_scope_path" };
+    }
+    const parsed = parseRoomPath(roomPath);
+    if (parsed.kind !== "owner-named") {
+      return { result: "error", code: "unsupported_room_kind" };
+    }
+    if (parsed.owner !== this.peerId) {
+      return { result: "error", code: "not_owner" };
+    }
+
+    const key = `${roomPath}::${handle.id}`;
+    const decision = await new Promise<"accept" | "reject">((resolve) => {
+      this.pendingRoomJoins.set(key, {
+        roomPath,
+        requesterId: handle.id,
+        resolve,
+      });
+    });
+    this.pendingRoomJoins.delete(key);
+    if (decision === "reject") {
+      return { result: "error", code: "denied" };
+    }
+
+    // Only identity/clock are needed here: the granted token belongs to the requester's own node, which persists it itself once it receives this response, not this store's own identity slot.
+    const { identity, clock } = this.requireIdentity();
+    const verdict = await mintCapabilityToken({
+      identity,
+      clock,
+      tokenId: randomTokenId(),
+      bearer: deviceIdFromHex(handle.id),
+      capability: "room:member",
+      scope: { kind: "room", path: roomPath },
+      expires: clock.now() + ROOM_TOKEN_LIFETIME_MS,
+      delegationsRemaining: 0,
+    });
+    if (!verdict.ok) {
+      return { result: "error", code: "mint_failed" };
+    }
+
+    const room = this.rooms.get(roomPath);
+    if (room !== undefined) {
+      this.bump(room);
+      this.recordMemberOp(room, "member", "join", handle.id);
+      this.refreshMembership(room);
+      this.rooms.set(roomPath, room);
+    }
+
+    const members = (room?.members ?? [this.peerId, handle.id]).map(
+      (memberId) => ({ device: deviceIdFromHex(memberId) }),
+    );
+    return { result: "ok", "granted-token": verdict.token, members };
+  }
+
+  /** Every room.join request currently held open awaiting this store's own accept/reject decision. */
+  listPendingRoomJoins(): { roomPath: string; requesterId: string }[] {
+    return [...this.pendingRoomJoins.values()].map(
+      ({ roomPath, requesterId }) => ({ roomPath, requesterId }),
+    );
+  }
+
+  /** Approves a pending room.join request, resuming handleRoomJoin's own suspended mint-and-respond continuation. */
+  acceptRoomJoin(roomPath: string, requesterId: string): void {
+    const key = `${roomPath}::${requesterId}`;
+    const pending = this.pendingRoomJoins.get(key);
+    if (pending === undefined) {
+      throw new CommsError(
+        `No pending room.join for ${requesterId} on ${roomPath}`,
+        "NOT_PENDING",
+      );
+    }
+    pending.resolve("accept");
+  }
+
+  /** Denies a pending room.join request. */
+  rejectRoomJoin(roomPath: string, requesterId: string): void {
+    const key = `${roomPath}::${requesterId}`;
+    const pending = this.pendingRoomJoins.get(key);
+    if (pending === undefined) {
+      throw new CommsError(
+        `No pending room.join for ${requesterId} on ${roomPath}`,
+        "NOT_PENDING",
+      );
+    }
+    pending.resolve("reject");
+  }
+
   async createRoom(opts: {
     name: string;
     type: RoomType;
@@ -1260,10 +1389,71 @@ export class MeshStore implements CommsStore {
     return result;
   }
 
+  /**
+   * The remote-join path: roomPath names an owner-named room this store has never seen replicated, so joining it means sending a real wire-level room.join request to the room's own owner and persisting whatever grant comes back, rather than mutating already-known local state. Only ever called for this store's own local agent (one bridge is one agent is one device, per the design's own organising fact) -- there is no wire mechanism by which this node could join a room on a different local agent's behalf.
+   */
+  private async joinRemoteRoom(
+    roomPath: string,
+    agentId: string,
+  ): Promise<Room> {
+    if (agentId !== this.peerId) {
+      throw new CommsError(`Room ${roomPath} not found`, "ROOM_NOT_FOUND");
+    }
+    const parsed = parseRoomPath(roomPath);
+    if (parsed.kind !== "owner-named") {
+      throw new CommsError(`Room ${roomPath} not found`, "ROOM_NOT_FOUND");
+    }
+
+    const outcome = await this.requireTransport().sendRoomRequest(
+      parsed.owner,
+      { verb: ROOM_MEMBER_CAPABILITY, params: { verb: "room.join" } },
+      { kind: "room", path: roomPath },
+    );
+    if (outcome.result !== "ok") {
+      throw new CommsError(
+        `Join request for ${roomPath} was refused (${outcome.code})`,
+        "JOIN_REFUSED",
+      );
+    }
+    const parsedOutcome = roomJoinOkSchema.safeParse(outcome);
+    if (!parsedOutcome.success) {
+      throw new CommsError(
+        `Join response for ${roomPath} was malformed`,
+        "MALFORMED_RESPONSE",
+      );
+    }
+    const { "granted-token": grantedToken, members: memberList } =
+      parsedOutcome.data;
+
+    const { slot } = this.requireIdentity();
+    saveRoomToken(slot, roomPath, grantedToken);
+
+    const members = memberList.map((member) => deviceIdToHex(member.device));
+    const room: Room = {
+      id: roomPath,
+      version: 1,
+      name: parsed.localName,
+      // The wire-level room.join response carries no room type or description -- that metadata is P3.6's own job (the room.members response's namespaced room-state extension). "public" is inert here rather than a real classification: the one place type is read (listRooms' secret-room filter) never hides a room from its own member, and this joiner is always in `members` by construction.
+      type: "public",
+      owner: parsed.owner,
+      createdAt: new Date().toISOString(),
+      description: "",
+      members,
+      invited: [],
+      memberJoins: Object.fromEntries(members.map((member) => [member, 1])),
+      memberLeaves: {},
+      invitedJoins: {},
+      invitedLeaves: {},
+      federated: false,
+    };
+    this.rooms.set(roomPath, room);
+    this.messages.set(roomPath, []);
+    return room;
+  }
+
   async joinRoom(roomId: string, agentId: string): Promise<Room> {
     const room = this.rooms.get(roomId);
-    if (!room)
-      throw new CommsError(`Room ${roomId} not found`, "ROOM_NOT_FOUND");
+    if (!room) return this.joinRemoteRoom(roomId, agentId);
 
     const alreadyMember = room.members.includes(agentId);
     if (!alreadyMember && room.type !== "public") {

--- a/src/core/room-token-verification.ts
+++ b/src/core/room-token-verification.ts
@@ -15,8 +15,8 @@ import type {
 } from "wire-mesh-core/generated/protocol";
 import { parseRoomPath } from "./room-path.js";
 
-/** The one capability that authorises every ordinary room-membership verb (room.send/read/leave/members) -- "one resource, not several", the same pattern exec:pty already uses for its own four inner verbs. room.join/room.invite are deliberately ungated and never reach this check at all. */
-const ROOM_MEMBER_CAPABILITY = "room:member";
+/** The one capability that authorises every ordinary room-membership verb (room.send/read/leave/members) -- "one resource, not several", the same pattern exec:pty already uses for its own four inner verbs. room.join/room.invite are deliberately ungated and never reach this check at all. This same string is also the outer manage-command's own verb for every room-domain command (gated or ungated): core/room's own convention puts the specific action in params.verb, with command.verb fixed to this capability name -- exported so wire-level command construction (see wire-mesh-transport.ts/mesh-store.ts) shares this one constant rather than a second, independently-typed copy of the same literal. */
+export const ROOM_MEMBER_CAPABILITY = "room:member";
 
 export type RoomTokenVerdictReason =
   | TokenVerdictReason

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -18,6 +18,12 @@
  */
 
 import type { MeshMessage, PeerInfo } from "./wire-protocol.js";
+import type {
+  CapabilityScope,
+  CapabilityToken,
+  ManageCommand,
+} from "wire-mesh-core/generated/protocol";
+import type { ManageOutcome } from "wire-mesh-core/domain/mesh-session";
 
 // ---------------------------------------------------------------------------
 // Connection handle — opaque reference to a specific peer connection
@@ -197,6 +203,16 @@ export interface MeshTransport {
    * Broadcast a wire message to all connected peer data connections.
    */
   broadcast(message: MeshMessage): Promise<void>;
+
+  /**
+   * Sends a real core/room manage-request to a specific member's own established session, returning its outcome (e.g. a room.join request's granted-token, or a room.send's delivery receipt) rather than swallowing it the way send() does for the legacy opaque-frame path. Resolves to a not_connected error outcome if no live session to that member exists, rather than throwing -- the caller (currently room-join, and P3.5's directed fan-out once it lands) decides how to react to an unreachable member.
+   */
+  sendRoomRequest(
+    memberId: string,
+    command: ManageCommand,
+    scope: Readonly<CapabilityScope>,
+    token?: CapabilityToken,
+  ): Promise<ManageOutcome>;
 
   /**
    * Add a coordinator listener on a specific adapter.

--- a/src/core/wire-mesh-transport.ts
+++ b/src/core/wire-mesh-transport.ts
@@ -13,10 +13,12 @@ import {
   acceptMeshSession,
   type AcceptedMeshSession,
   type IncomingManageRequest,
+  type ManageOutcome,
 } from "wire-mesh-core/domain/mesh-session";
 import { deviceIdToHex } from "wire-mesh-core/domain/device-id";
 import type {
   CapabilityScope,
+  CapabilityToken,
   ManageCommand,
 } from "wire-mesh-core/generated/protocol";
 import type {
@@ -39,6 +41,7 @@ import {
   createRoomRouter,
   extractMessage,
   type RoomRouter,
+  type RoomVerbHandler,
 } from "./room-router.js";
 
 // ---------------------------------------------------------------------------
@@ -150,14 +153,21 @@ export class WireMeshTransport implements MeshTransport {
   // -- The single consumer of every approved session's incomingManageRequests, once quarantine (if any) is past. Owns verb dispatch (the legacy opaque frame, plus whichever real core/room verbs later phases register handlers for) -- this transport itself no longer decodes or routes a MeshMessage at all beyond handing a session off here.
   private readonly roomRouter: RoomRouter;
 
-  constructor(events: TransportEvents, identity: Readonly<PeerIdentity>) {
+  constructor(
+    events: TransportEvents,
+    identity: Readonly<PeerIdentity>,
+    roomVerbHandlers?: Partial<Record<string, RoomVerbHandler>>,
+  ) {
     this.events = events;
     this.wireTransport = createTlsTransport({
       certificatePem: identity.certificate,
       privateKeyPem: identity.privateKey,
     });
     this.identityReady = toIdentityPort(identity);
-    this.roomRouter = createRoomRouter({ events });
+    this.roomRouter = createRoomRouter({
+      events,
+      ...(roomVerbHandlers !== undefined ? { handlers: roomVerbHandlers } : {}),
+    });
   }
 
   // -- Public getters --
@@ -486,6 +496,19 @@ export class WireMeshTransport implements MeshTransport {
         session.sendManageRequest(command, FRAME_SCOPE).catch(() => undefined),
       ),
     );
+  }
+
+  async sendRoomRequest(
+    memberId: string,
+    command: ManageCommand,
+    scope: Readonly<CapabilityScope>,
+    token?: CapabilityToken,
+  ): Promise<ManageOutcome> {
+    const session = this.peerSessions.get(memberId);
+    if (session === undefined) {
+      return { result: "error", code: "not_connected" };
+    }
+    return session.sendManageRequest(command, scope, undefined, token);
   }
 
   // -----------------------------------------------------------------------

--- a/src/test/downtime-replay.integration.test.ts
+++ b/src/test/downtime-replay.integration.test.ts
@@ -37,7 +37,9 @@ async function makePeer(
 ): Promise<Peer> {
   const store = new MeshStore(TEST_PORT);
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
-  store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setTransport(
+    new WireMeshTransport(store.events, identity, store.roomVerbHandlers),
+  );
   store.setIdentity({
     identity: await toIdentityPort(identity),
     clock: createSystemClock(),

--- a/src/test/identity-restart.integration.test.ts
+++ b/src/test/identity-restart.integration.test.ts
@@ -37,7 +37,9 @@ async function makePeer(
 ): Promise<Peer> {
   const store = new MeshStore(TEST_PORT);
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
-  store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setTransport(
+    new WireMeshTransport(store.events, identity, store.roomVerbHandlers),
+  );
   store.setIdentity({
     identity: await toIdentityPort(identity),
     clock: createSystemClock(),

--- a/src/test/room-join-admission.test.ts
+++ b/src/test/room-join-admission.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for room.join admission (P3.4): the owner-side handler that holds a request open until a human decides, and the requester-side joinRoom path that sends a real wire-level request for a room this store has never seen replicated.
+ *
+ * Deliberately unit-level, not a full two-peer integration test: MeshStore's own legacy full-state-sync (still active per P3.3's "both paths coexist" transition) makes any two mesh-connected stores instantly aware of every room the moment they connect, so a genuinely two-peer test can never actually exercise the "room I've never heard of" case this code exists for -- exactly the scenario section 4 of the design doc names as a real regression, not something a live two-store test can reach today. Testing the handler and the remote-join path directly, against fakes, is the only way to exercise this code before P3.8 retires the legacy path.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type {
+  IncomingManageRequest,
+  ManageOutcome,
+} from "wire-mesh-core/domain/mesh-session";
+import {
+  deviceIdFromHex,
+  deviceIdToHex,
+} from "wire-mesh-core/domain/device-id";
+import { createSystemClock } from "wire-mesh-core/adapters/system-clock";
+import { mintCapabilityToken } from "wire-mesh-core/domain/tokens";
+import { MeshStore } from "../core/mesh-store.js";
+import { ownerNamedRoomPath } from "../core/room-path.js";
+import {
+  loadOrCreateIdentity,
+  loadRoomTokens,
+} from "../core/identity-store.js";
+import type { IdentitySlot } from "../core/identity-store.js";
+import { toIdentityPort } from "../core/wire-mesh-identity.js";
+import type { ConnectionHandle, MeshTransport } from "../core/transport.js";
+import { wireTestTransport } from "./test-transport.js";
+
+const REQUESTER_ID = "b".repeat(64);
+
+function fakeRequest(scopePath: string): {
+  request: IncomingManageRequest;
+  responses: ManageOutcome[];
+} {
+  const responses: ManageOutcome[] = [];
+  const request: IncomingManageRequest = {
+    requestId: 1,
+    command: { verb: "room:member", params: { verb: "room.join" } },
+    scope: { kind: "room", path: scopePath },
+    respond: async (outcome: ManageOutcome): Promise<void> => {
+      responses.push(outcome);
+    },
+  };
+  return { request, responses };
+}
+
+describe("handleRoomJoin (owner side)", () => {
+  it("holds the request open, then grants a working token on acceptance", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const owner = await store.registerAgent({
+      name: "owner",
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+      visibility: "visible",
+      tags: [],
+    });
+    const room = await store.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.id,
+      description: "",
+    });
+
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler, "expected a registered room.join handler");
+    const handle: ConnectionHandle = { id: REQUESTER_ID };
+    const { request } = fakeRequest(room.id);
+
+    const outcomePromise = handler(request, handle);
+
+    assert.deepEqual(store.listPendingRoomJoins(), [
+      { roomPath: room.id, requesterId: REQUESTER_ID },
+    ]);
+
+    store.acceptRoomJoin(room.id, REQUESTER_ID);
+    const outcome = await outcomePromise;
+
+    assert.equal(outcome.result, "ok");
+    if (outcome.result !== "ok") return;
+    assert.deepEqual(store.listPendingRoomJoins(), []);
+
+    const token = outcome["granted-token"];
+    assert.ok(token !== undefined, "expected a granted-token in the outcome");
+
+    const roomAfterJoin = await store.getRoom(room.id);
+    assert.ok(roomAfterJoin?.members.includes(REQUESTER_ID));
+  });
+
+  it("denies the request without minting anything on rejection", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const owner = await store.registerAgent({
+      name: "owner",
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+      visibility: "visible",
+      tags: [],
+    });
+    const room = await store.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.id,
+      description: "",
+    });
+
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler);
+    const handle: ConnectionHandle = { id: REQUESTER_ID };
+    const { request } = fakeRequest(room.id);
+
+    const outcomePromise = handler(request, handle);
+    store.rejectRoomJoin(room.id, REQUESTER_ID);
+    const outcome = await outcomePromise;
+
+    assert.equal(outcome.result, "error");
+    const roomAfterReject = await store.getRoom(room.id);
+    assert.equal(roomAfterReject?.members.includes(REQUESTER_ID), false);
+  });
+
+  it("refuses a DM path outright, with no pending entry created", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const dmPath = `${deviceIdToHex(deviceIdFromHex("c".repeat(64)))}+${deviceIdToHex(deviceIdFromHex("d".repeat(64)))}`;
+
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler);
+    const handle: ConnectionHandle = { id: REQUESTER_ID };
+    const { request } = fakeRequest(dmPath);
+
+    const outcome = await handler(request, handle);
+
+    assert.equal(outcome.result, "error");
+    assert.deepEqual(store.listPendingRoomJoins(), []);
+  });
+
+  it("refuses a named room this store doesn't own", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const someoneElse = "e".repeat(64);
+    const roomPath = ownerNamedRoomPath(someoneElse, "general");
+
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler);
+    const handle: ConnectionHandle = { id: REQUESTER_ID };
+    const { request } = fakeRequest(roomPath);
+
+    const outcome = await handler(request, handle);
+
+    assert.equal(outcome.result, "error");
+    assert.deepEqual(store.listPendingRoomJoins(), []);
+  });
+});
+
+describe("joinRoom (requester side, remote path)", () => {
+  it("sends a real room.join request and persists the granted token for a room it has never seen", async () => {
+    const store = new MeshStore();
+    const slot: IdentitySlot = {
+      harness: "test",
+      cwd: "req",
+      dir: fs.mkdtempSync(path.join(tmpdir(), "agent-comms-join-remote-")),
+    };
+    const identity = loadOrCreateIdentity(slot);
+    store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
+    const identityPort = await toIdentityPort(identity);
+    store.setIdentity({
+      identity: identityPort,
+      clock: createSystemClock(),
+      slot,
+    });
+
+    const ownerId = "f".repeat(64);
+    const roomPath = ownerNamedRoomPath(ownerId, "general");
+    // A real, validly-minted token -- roomJoinOkSchema validates the wire response's own granted-token shape against the real CapabilityToken schema, so a hand-rolled fixture would just fail that validation. Minted here by the requester's own identity purely as a stand-in for "any real token the owner could have sent"; who actually signed it plays no part in this test, only that saveRoomToken's own CapabilityToken contract is satisfied.
+    const grantedTokenVerdict = await mintCapabilityToken({
+      identity: identityPort,
+      clock: createSystemClock(),
+      tokenId: new Uint8Array([1]),
+      bearer: deviceIdFromHex(store.peerId),
+      capability: "room:member",
+      scope: { kind: "room", path: roomPath },
+      expires: Date.now() + 60_000,
+      delegationsRemaining: 0,
+    });
+    assert.ok(
+      grantedTokenVerdict.ok,
+      "expected the fixture token to mint successfully",
+    );
+    if (!grantedTokenVerdict.ok) return;
+    const grantedToken = grantedTokenVerdict.token;
+
+    let capturedRoomPath: string | undefined;
+    const fakeTransport: MeshTransport = {
+      dataPort: 0,
+      isCoordinator: false,
+      hasCoordinatorConnection: false,
+      startDataServer: async () => {},
+      connectToCoordinator: async () => {},
+      becomeCoordinator: async () => {},
+      connectToPeer: async () => {},
+      send: async () => {},
+      acceptConnection: async () => {},
+      rejectConnection: async () => {},
+      connectToRemote: async () => {},
+      broadcast: async () => {},
+      sendRoomRequest: async (_memberId, command, scope) => {
+        capturedRoomPath = scope.path;
+        assert.deepEqual(command.params, { verb: "room.join" });
+        return {
+          result: "ok",
+          "granted-token": grantedToken,
+          members: [{ device: deviceIdFromHex(store.peerId) }],
+        };
+      },
+      addListener: async () => "id",
+      removeListener: async () => {},
+      listListeners: () => [],
+      shutdown: async () => {},
+      unref: () => {},
+    };
+    store.setTransport(fakeTransport);
+
+    assert.equal(await store.getRoom(roomPath), undefined);
+
+    const joined = await store.joinRoom(roomPath, store.peerId);
+
+    assert.equal(joined.id, roomPath);
+    assert.equal(capturedRoomPath, roomPath);
+    assert.ok(joined.members.includes(store.peerId));
+
+    const tokens = loadRoomTokens(slot);
+    assert.ok(
+      tokens[roomPath] !== undefined,
+      "expected the granted token to be persisted",
+    );
+  });
+});

--- a/src/test/test-transport.ts
+++ b/src/test/test-transport.ts
@@ -25,7 +25,9 @@ export async function wireTestTransport(
   const identity = loadOrCreateIdentity(resolvedSlot);
   // Every real bridge sets peerId to deviceIdToHex(identity.deviceId) before wiring the transport (createBridgeMesh) -- WireMeshTransport's own session bookkeeping is keyed by device-id, so a peer's advertised ID and the identity the other side actually authenticates the connection against must be the same value, or introduction/state-sync never recognises the peer as itself.
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
-  store.setTransport(new WireMeshTransport(store.events, identity));
+  store.setTransport(
+    new WireMeshTransport(store.events, identity, store.roomVerbHandlers),
+  );
   store.setIdentity({
     identity: await toIdentityPort(identity),
     clock: createSystemClock(),


### PR DESCRIPTION
Part of #48 (P3.4: admission -- room.join, room.invite, approval).

Second slice of P3.4, building on #72 (the owner's own self-signed root grant): a real, working `room.join` round trip. `WireMeshTransport` gains `sendRoomRequest(memberId, command, scope, token)` -- the same method the design doc's own directed-fan-out phase (P3.5) already names, built now since room.join needs it and P3.5 can reuse it rather than inventing it twice. `MeshStore` registers a `room.join` handler that holds the incoming request open until a human calls the new `acceptRoomJoin`/`rejectRoomJoin`, then mints and returns an independent, parent-less `room:member` grant. `joinRoom`'s own client side now sends a real wire-level request when the target room isn't already known locally, instead of only ever operating on already-replicated state.

Real bug caught while writing this: I initially set the outer `command.verb` to `"room.join"` directly, which is wrong -- core/room's own convention (established earlier this session, verified against wire-mesh's own conformance vectors) is that `command.verb` is always the fixed capability string `"room:member"`, with the specific action in `command.params.verb`. Fixed, and `ROOM_MEMBER_CAPABILITY` promoted from a private constant in `room-token-verification.ts` to an exported one so this convention has exactly one source of truth.

Also found while writing the test: a genuinely two-real-peer integration test can't actually exercise this new remote-join path today. The legacy full-state-sync mechanism (still active per the "both paths coexist" transition) replicates a store's entire room table to any newly-connected peer, and `createRoom`'s own broadcast reaches every already-connected peer immediately -- so two ordinarily mesh-connected stores are never in the "requester has never heard of this room" state the new code exists for. Confirmed this the hard way: wrote the two-peer test first, watched it hang for the full timeout, and found the requester already had the room via the old gossip path by the time it tried to join. Tested at the unit level instead (real `MeshStore` + a fake request/handle for the owner side, real `MeshStore` + a fake `MeshTransport` for the requester side), matching `room-router.test.ts`'s own existing style -- this is a real, if temporary, limit on what a live two-peer test can prove until P3.8 retires the legacy protocol, not a gap in this PR's own coverage.

Deliberately out of scope for this slice, refused outright rather than mishandled: a DM path (section 6's own two-round consent flow), and `room.invite`'s own receiving side (blocked on P3.6's room-state metadata, per the note already on #48). Not yet wired to any `CommsTool` action or bridge UI either -- `acceptRoomJoin`/`rejectRoomJoin`/`listPendingRoomJoins` are directly callable on `MeshStore` only for now.