### PR TITLE
feat(core): expose room.join admission through room_accept/room_reject/room_pending

### DIFF
--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -52,6 +52,9 @@ export const MCP_TOOL_PARAMS = z.object({
     "mesh_accept",
     "mesh_reject",
     "mesh_pending",
+    "room_accept",
+    "room_reject",
+    "room_pending",
     "mesh_discover",
     "mesh_advertise",
     "mesh_unadvertise",
@@ -86,6 +89,7 @@ export const MCP_TOOL_PARAMS = z.object({
   id: z.string().optional(),
   meshVisibility: MeshVisibilityEnum.optional(),
   connectionId: z.string().optional(),
+  requesterId: z.string().optional(),
   streamingBehavior: z.enum(["steer", "followUp", "info"]).optional(),
 });
 
@@ -261,6 +265,31 @@ export function buildAction(params: Record<string, unknown>): CommsAction {
     }
     case "mesh_pending":
       return { action: "mesh_pending" };
+    case "room_accept": {
+      if (p.room === undefined)
+        throw new BuildActionError("room_accept", "room");
+      if (p.requesterId === undefined)
+        throw new BuildActionError("room_accept", "requesterId");
+      return {
+        action: "room_accept",
+        room: p.room,
+        requesterId: p.requesterId,
+      };
+    }
+    case "room_reject": {
+      if (p.room === undefined)
+        throw new BuildActionError("room_reject", "room");
+      if (p.requesterId === undefined)
+        throw new BuildActionError("room_reject", "requesterId");
+      return {
+        action: "room_reject",
+        room: p.room,
+        requesterId: p.requesterId,
+        ...(p.reason !== undefined && { reason: p.reason }),
+      };
+    }
+    case "room_pending":
+      return { action: "room_pending" };
     case "mesh_discover": {
       const discover: CommsAction & { action: "mesh_discover" } = {
         action: "mesh_discover",

--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -90,6 +90,10 @@ export interface MeshStoreIdentity {
  */
 const ROOM_TOKEN_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
 
+/** A human's decision on a pending room.join request -- reject carries an optional reason, mirroring rejectConnection's own equivalent room-independent decision. */
+type RoomJoinDecision =
+  { kind: "accept" } | { kind: "reject"; reason?: string };
+
 /**
  * Bound on pending delivery events held per target agent. Events beyond the
  * bound drop oldest-first: a long-offline agent's queue cannot grow without
@@ -164,7 +168,7 @@ export class MeshStore implements CommsStore {
     {
       roomPath: string;
       requesterId: string;
-      resolve: (decision: "accept" | "reject") => void;
+      resolve: (decision: RoomJoinDecision) => void;
     }
   >();
 
@@ -1258,7 +1262,7 @@ export class MeshStore implements CommsStore {
     }
 
     const key = `${roomPath}::${handle.id}`;
-    const decision = await new Promise<"accept" | "reject">((resolve) => {
+    const decision = await new Promise<RoomJoinDecision>((resolve) => {
       this.pendingRoomJoins.set(key, {
         roomPath,
         requesterId: handle.id,
@@ -1266,8 +1270,12 @@ export class MeshStore implements CommsStore {
       });
     });
     this.pendingRoomJoins.delete(key);
-    if (decision === "reject") {
-      return { result: "error", code: "denied" };
+    if (decision.kind === "reject") {
+      return {
+        result: "error",
+        code: "denied",
+        ...(decision.reason !== undefined ? { message: decision.reason } : {}),
+      };
     }
 
     // Only identity/clock are needed here: the granted token belongs to the requester's own node, which persists it itself once it receives this response, not this store's own identity slot.
@@ -1317,11 +1325,11 @@ export class MeshStore implements CommsStore {
         "NOT_PENDING",
       );
     }
-    pending.resolve("accept");
+    pending.resolve({ kind: "accept" });
   }
 
-  /** Denies a pending room.join request. */
-  rejectRoomJoin(roomPath: string, requesterId: string): void {
+  /** Denies a pending room.join request, optionally with a reason surfaced to the requester in the resulting manage-error's own message field. */
+  rejectRoomJoin(roomPath: string, requesterId: string, reason?: string): void {
     const key = `${roomPath}::${requesterId}`;
     const pending = this.pendingRoomJoins.get(key);
     if (pending === undefined) {
@@ -1330,7 +1338,10 @@ export class MeshStore implements CommsStore {
         "NOT_PENDING",
       );
     }
-    pending.resolve("reject");
+    pending.resolve({
+      kind: "reject",
+      ...(reason !== undefined ? { reason } : {}),
+    });
   }
 
   async createRoom(opts: {

--- a/src/core/tool.ts
+++ b/src/core/tool.ts
@@ -61,6 +61,9 @@ export interface MeshOnlyFeatures {
     name: string;
     fingerprint: string;
   }[];
+  acceptRoomJoin?(roomPath: string, requesterId: string): void;
+  rejectRoomJoin?(roomPath: string, requesterId: string, reason?: string): void;
+  listPendingRoomJoins?(): { roomPath: string; requesterId: string }[];
   connectToRemote?(host: string, port: number): Promise<void>;
   setVisibility?(level: MeshVisibility, adapter?: string): Promise<void>;
   getVisibility?(adapter?: string): MeshVisibility;
@@ -121,6 +124,12 @@ export class CommsTool {
           return await this.meshReject(ctx, action);
         case "mesh_pending":
           return this.meshPending(ctx);
+        case "room_accept":
+          return this.roomAccept(ctx, action);
+        case "room_reject":
+          return this.roomReject(ctx, action);
+        case "room_pending":
+          return this.roomPending(ctx);
         case "mesh_discover":
           return await this.meshDiscover(action);
         case "mesh_advertise":
@@ -796,6 +805,57 @@ export class CommsTool {
     );
     return {
       content: `Pending connections:\n${lines.join("\n")}`,
+      isError: false,
+    };
+  }
+
+  private roomAccept(
+    _ctx: CommsContext,
+    action: CommsAction & { action: "room_accept" },
+  ): CommsResult {
+    if (!this.store.acceptRoomJoin) return notMeshBacked("room_accept");
+    try {
+      this.store.acceptRoomJoin(action.room, action.requesterId);
+      return {
+        content: `Accepted ${action.requesterId}'s request to join ${action.room}.`,
+        isError: false,
+      };
+    } catch (err) {
+      return {
+        content: `Failed to accept: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+  }
+
+  private roomReject(
+    _ctx: CommsContext,
+    action: CommsAction & { action: "room_reject" },
+  ): CommsResult {
+    if (!this.store.rejectRoomJoin) return notMeshBacked("room_reject");
+    try {
+      this.store.rejectRoomJoin(action.room, action.requesterId, action.reason);
+      return {
+        content: `Rejected ${action.requesterId}'s request to join ${action.room}.`,
+        isError: false,
+      };
+    } catch (err) {
+      return {
+        content: `Failed to reject: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+  }
+
+  private roomPending(_ctx: CommsContext): CommsResult {
+    if (!this.store.listPendingRoomJoins) return notMeshBacked("room_pending");
+    const pending = this.store.listPendingRoomJoins();
+    if (pending.length === 0)
+      return { content: "No pending room join requests.", isError: false };
+
+    const lines = pending.map((p) => `${p.roomPath}  ${p.requesterId}`);
+    return {
+      content: `Pending room join requests:\n${lines.join("\n")}`,
       isError: false,
     };
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -340,6 +340,18 @@ export const CommsActionSchema = defineSchema(
     }),
     z.object({ action: z.literal("mesh_pending") }),
     z.object({
+      action: z.literal("room_accept"),
+      room: z.string(),
+      requesterId: z.string(),
+    }),
+    z.object({
+      action: z.literal("room_reject"),
+      room: z.string(),
+      requesterId: z.string(),
+      reason: z.string().optional(),
+    }),
+    z.object({ action: z.literal("room_pending") }),
+    z.object({
       action: z.literal("mesh_discover"),
       method: z.string().optional(),
     }),

--- a/src/test/room-admission-tool-actions.test.ts
+++ b/src/test/room-admission-tool-actions.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the room_accept/room_reject/room_pending CommsTool actions -- the human-facing wrapper around MeshStore's own acceptRoomJoin/rejectRoomJoin/listPendingRoomJoins, additive alongside (never replacing) the existing mesh_accept/mesh_reject/mesh_pending connection-level actions.
+ */
+
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { IncomingManageRequest } from "wire-mesh-core/domain/mesh-session";
+import { MeshStore } from "../core/mesh-store.js";
+import { CommsTool } from "../core/tool.js";
+import { buildAction } from "../core/bridge.js";
+import { wireTestTransport } from "./test-transport.js";
+
+const REQUESTER_ID = "b".repeat(64);
+
+function fakeJoinRequest(roomPath: string): IncomingManageRequest {
+  return {
+    requestId: 1,
+    command: { verb: "room:member", params: { verb: "room.join" } },
+    scope: { kind: "room", path: roomPath },
+    respond: async () => {},
+  };
+}
+
+describe("room admission CommsTool actions", () => {
+  it("room_pending lists a held-open room.join request", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const owner = await store.registerAgent({
+      name: "owner",
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+      visibility: "visible",
+      tags: [],
+    });
+    const room = await store.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.id,
+      description: "",
+    });
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler);
+    void handler(fakeJoinRequest(room.id), { id: REQUESTER_ID });
+
+    const tool = new CommsTool(store);
+    const ctx = {
+      agentId: owner.id,
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+    };
+    const pendingResult = await tool.handle(
+      ctx,
+      buildAction({ action: "room_pending" }),
+    );
+
+    assert.equal(pendingResult.isError, false);
+    assert.ok(pendingResult.content.includes(room.id));
+    assert.ok(pendingResult.content.includes(REQUESTER_ID));
+  });
+
+  it("room_accept grants the pending request", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const owner = await store.registerAgent({
+      name: "owner",
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+      visibility: "visible",
+      tags: [],
+    });
+    const room = await store.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.id,
+      description: "",
+    });
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler);
+    const outcomePromise = handler(fakeJoinRequest(room.id), {
+      id: REQUESTER_ID,
+    });
+
+    const tool = new CommsTool(store);
+    const ctx = {
+      agentId: owner.id,
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+    };
+    const acceptResult = await tool.handle(
+      ctx,
+      buildAction({
+        action: "room_accept",
+        room: room.id,
+        requesterId: REQUESTER_ID,
+      }),
+    );
+
+    assert.equal(acceptResult.isError, false);
+    const outcome = await outcomePromise;
+    assert.equal(outcome.result, "ok");
+
+    const pendingAfter = await tool.handle(
+      ctx,
+      buildAction({ action: "room_pending" }),
+    );
+    assert.equal(pendingAfter.content, "No pending room join requests.");
+  });
+
+  it("room_reject denies the pending request with an optional reason", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const owner = await store.registerAgent({
+      name: "owner",
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+      visibility: "visible",
+      tags: [],
+    });
+    const room = await store.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.id,
+      description: "",
+    });
+    const handler = store.roomVerbHandlers["room.join"];
+    assert.ok(handler);
+    const outcomePromise = handler(fakeJoinRequest(room.id), {
+      id: REQUESTER_ID,
+    });
+
+    const tool = new CommsTool(store);
+    const ctx = {
+      agentId: owner.id,
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+    };
+    const rejectResult = await tool.handle(
+      ctx,
+      buildAction({
+        action: "room_reject",
+        room: room.id,
+        requesterId: REQUESTER_ID,
+        reason: "not now",
+      }),
+    );
+
+    assert.equal(rejectResult.isError, false);
+    const outcome = await outcomePromise;
+    assert.equal(outcome.result, "error");
+    if (outcome.result === "error") {
+      assert.equal(outcome.message, "not now");
+    }
+  });
+
+  it("room_accept on a store with no matching pending request reports failure, not a crash", async () => {
+    const store = new MeshStore();
+    await wireTestTransport(store);
+    const owner = await store.registerAgent({
+      name: "owner",
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+      visibility: "visible",
+      tags: [],
+    });
+    const tool = new CommsTool(store);
+    const ctx = {
+      agentId: owner.id,
+      harness: "pi",
+      cwd: "/tmp/p",
+      pid: process.pid,
+    };
+
+    const result = await tool.handle(
+      ctx,
+      buildAction({
+        action: "room_accept",
+        room: "not-a-real-room",
+        requesterId: REQUESTER_ID,
+      }),
+    );
+
+    assert.equal(result.isError, true);
+  });
+});


### PR DESCRIPTION
Part of #48 (P3.4: admission -- room.join, room.invite, approval).

Third slice of P3.4, closing the operator-surface gap #73 explicitly flagged as out of scope: `acceptRoomJoin`/`rejectRoomJoin`/`listPendingRoomJoins` were only callable directly on `MeshStore`, with no way for a human to actually use them through any bridge. Adds three new, additive `CommsTool` actions -- `room_accept`/`room_reject`/`room_pending` -- following the exact same `MeshOnlyFeatures` optional-extension pattern the existing `mesh_accept`/`mesh_reject`/`mesh_pending` connection-level actions already use.

Deliberately additive, not a replacement: mesh-level connection approval and room-level admission stay two separate gates, matching the resolution to the open question #73 raised about whether "retarget" meant repointing the existing three actions at room admission instead. Repurposing them would mean either removing the connection-level security boundary or guessing at a design intent the doc doesn't spell out either way -- the safer, unambiguous choice is new actions that add capability without touching the existing ones.

`rejectRoomJoin` gained an optional `reason` parameter along the way, surfaced to the requester in the resulting `manage-error`'s own `message` field -- `rejectConnection` already has this, so `rejectRoomJoin` was missing it purely because the first version of this method didn't carry a reason through at all.

`pi`'s own tool schema doesn't expose `mesh_accept`/`mesh_reject`/`mesh_pending` either (confirmed by reading it, not assumed), so `room_accept`/`room_reject`/`room_pending` are left out there too, for the same reason -- adding only the room actions would be a new inconsistency, not a fix for an existing one.