### PR TITLE
feat(core): implement the two-round DM consent flow

### DIFF
--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -172,6 +172,9 @@ export class MeshStore implements CommsStore {
     }
   >();
 
+  // -- DM paths this store has itself sent an outbound room.join for -- section 6's own basis for auto-approving the counterpart's reciprocal room.join without a second human decision. Never cleared: a DM conversation, once opened, stays open, and holding a stale entry here costs nothing beyond a few bytes per DM this node has ever initiated.
+  private dmRequestsInitiatedByMe = new Set<string>();
+
   onDelivery:
     | ((agentId: string, event: DeliveryEvent) => void | Promise<void>)
     | undefined;
@@ -1243,7 +1246,7 @@ export class MeshStore implements CommsStore {
   }
 
   /**
-   * Owner-side admission for an incoming room.join request against a named room this store owns. Holds the request open (mirroring WireMeshTransport.consumeQuarantined's own connect_request pattern) until acceptRoomJoin/rejectRoomJoin settles it, then mints the requester a fresh, independent, parent-less room:member grant -- see mintOwnerRootGrant's own comment for why this is NOT chained through the owner's root grant. Refuses outright, with no pending entry created, for anything this phase doesn't yet handle: a DM path (section 6's own two-round consent flow, not built here) or a named room this store isn't the owner of.
+   * Owner-side admission for an incoming room.join request, against either a named room this store owns or a DM path this store is a participant of. Named-room admission always needs a human decision; DM admission needs one only for the party being contacted first -- the reply half of the two-round consent flow (section 6) auto-approves, since a reply on a path this node itself opened is not unsolicited contact.
    */
   private async handleRoomJoin(
     request: IncomingManageRequest,
@@ -1254,22 +1257,38 @@ export class MeshStore implements CommsStore {
       return { result: "error", code: "missing_scope_path" };
     }
     const parsed = parseRoomPath(roomPath);
-    if (parsed.kind !== "owner-named") {
-      return { result: "error", code: "unsupported_room_kind" };
-    }
-    if (parsed.owner !== this.peerId) {
-      return { result: "error", code: "not_owner" };
+
+    if (parsed.kind === "owner-named") {
+      if (parsed.owner !== this.peerId) {
+        return { result: "error", code: "not_owner" };
+      }
+      return this.admitRoomJoin(roomPath, handle, false);
     }
 
-    const key = `${roomPath}::${handle.id}`;
-    const decision = await new Promise<RoomJoinDecision>((resolve) => {
-      this.pendingRoomJoins.set(key, {
-        roomPath,
-        requesterId: handle.id,
-        resolve,
-      });
-    });
-    this.pendingRoomJoins.delete(key);
+    if (!parsed.participants.includes(this.peerId)) {
+      return { result: "error", code: "not_participant" };
+    }
+    // The reciprocal half of section 6's own two-round DM flow: this node's own outbound room.join to the same path (recorded by joinRemoteRoom before this response was even awaited) is the consent that makes the counterpart's own reply not unsolicited contact.
+    const autoApprove = this.dmRequestsInitiatedByMe.has(roomPath);
+    return this.admitRoomJoin(roomPath, handle, autoApprove);
+  }
+
+  /** Shared admission continuation for both room.join branches above: waits for a human decision (unless auto-approved), then mints and returns the requester's own independent, parent-less room:member grant. */
+  private async admitRoomJoin(
+    roomPath: string,
+    handle: ConnectionHandle,
+    autoApprove: boolean,
+  ): Promise<ManageOutcome> {
+    const decision: RoomJoinDecision = autoApprove
+      ? { kind: "accept" }
+      : await new Promise<RoomJoinDecision>((resolve) => {
+          this.pendingRoomJoins.set(`${roomPath}::${handle.id}`, {
+            roomPath,
+            requesterId: handle.id,
+            resolve,
+          });
+        });
+    if (!autoApprove) this.pendingRoomJoins.delete(`${roomPath}::${handle.id}`);
     if (decision.kind === "reject") {
       return {
         result: "error",
@@ -1460,6 +1479,34 @@ export class MeshStore implements CommsStore {
     this.rooms.set(roomPath, room);
     this.messages.set(roomPath, []);
     return room;
+  }
+
+  /**
+   * The requester's own half of section 6's two-round DM consent flow: sends an ungated room.join scoped to dmRoomPath(this, counterpart) directly to the counterpart, records having initiated it so the counterpart's own reciprocal room.join back auto-approves rather than surfacing as a fresh, unsolicited request, and persists whatever grant comes back. Deliberately outside the CommsStore interface, like connection approval, since it is a wire-mesh-specific concern FileStore has no equivalent for. Safe to call again for the same counterpart later (e.g. after an earlier request expired or was rejected) -- it always sends a fresh request rather than checking for an existing token first.
+   */
+  async requestDmAccess(counterpart: string): Promise<void> {
+    const dmPath = dmRoomPath(this.peerId, counterpart);
+    this.dmRequestsInitiatedByMe.add(dmPath);
+    const outcome = await this.requireTransport().sendRoomRequest(
+      counterpart,
+      { verb: ROOM_MEMBER_CAPABILITY, params: { verb: "room.join" } },
+      { kind: "room", path: dmPath },
+    );
+    if (outcome.result !== "ok") {
+      throw new CommsError(
+        `DM access request to ${counterpart} was refused (${outcome.code})`,
+        "JOIN_REFUSED",
+      );
+    }
+    const parsedOutcome = roomJoinOkSchema.safeParse(outcome);
+    if (!parsedOutcome.success) {
+      throw new CommsError(
+        `DM access response from ${counterpart} was malformed`,
+        "MALFORMED_RESPONSE",
+      );
+    }
+    const { slot } = this.requireIdentity();
+    saveRoomToken(slot, dmPath, parsedOutcome.data["granted-token"]);
   }
 
   async joinRoom(roomId: string, agentId: string): Promise<Room> {

--- a/src/test/dm-admission.integration.test.ts
+++ b/src/test/dm-admission.integration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration test for the DM two-round consent flow (P3.4, section 6): A requesting DM access to B needs one human decision from B; B's own reciprocal request back to A needs none, since A's own outbound request is already the consent that makes B's reply not unsolicited contact.
+ *
+ * Unlike named-room admission, a real two-peer test can actually exercise this: dmRequestsInitiatedByMe and the persisted room-token store are both purely local state legacy full-state-sync never touches, so two ordinarily mesh-connected peers stay in the "never DM'd before" state this flow exists for.
+ */
+
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import { MeshStore } from "../core/mesh-store.js";
+import { dmRoomPath } from "../core/room-path.js";
+import { waitFor, wireTestTransport } from "./test-transport.js";
+
+let nextPort = 20_950;
+function freshPort(): number {
+  nextPort += 1;
+  return nextPort;
+}
+
+async function makeConnectedPair(
+  port: number,
+): Promise<{ a: MeshStore; b: MeshStore }> {
+  const a = new MeshStore(port);
+  await wireTestTransport(a);
+  await a.init();
+  await a.registerAgent({
+    name: "a",
+    harness: "test",
+    cwd: "/test/a",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+
+  const b = new MeshStore(port);
+  await wireTestTransport(b);
+  await b.init();
+  await b.registerAgent({
+    name: "b",
+    harness: "test",
+    cwd: "/test/b",
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+
+  await waitFor(
+    () => a.serialise().agents[b.peerId] !== undefined,
+    "a sees b's agent",
+  );
+  return { a, b };
+}
+
+void test("A's DM request holds open for B's decision; B's reply back auto-approves", async () => {
+  const { a, b } = await makeConnectedPair(freshPort());
+
+  try {
+    const dmPath = dmRoomPath(a.peerId, b.peerId);
+
+    // A initiates: held open on B's side until a human decides.
+    const aRequestPromise = a.requestDmAccess(b.peerId);
+    await waitFor(
+      () => b.listPendingRoomJoins().length === 1,
+      "B sees A's pending DM request",
+    );
+    const [pending] = b.listPendingRoomJoins();
+    assert.equal(pending?.roomPath, dmPath);
+    assert.equal(pending?.requesterId, a.peerId);
+
+    b.acceptRoomJoin(dmPath, a.peerId);
+    await aRequestPromise;
+
+    // B's own reply, to the identical path, must NOT surface as a second pending decision on A's side -- A's own outbound request already covers it.
+    const bRequestPromise = b.requestDmAccess(a.peerId);
+    await bRequestPromise;
+    assert.deepEqual(a.listPendingRoomJoins(), []);
+  } finally {
+    await b.shutdown();
+    await a.shutdown();
+  }
+});
+
+void test("an unsolicited DM request (no prior outbound request) still needs a human decision", async () => {
+  const { a, b } = await makeConnectedPair(freshPort());
+
+  try {
+    const dmPath = dmRoomPath(a.peerId, b.peerId);
+
+    const requestPromise = b.requestDmAccess(a.peerId);
+    await waitFor(
+      () => a.listPendingRoomJoins().length === 1,
+      "A sees B's pending DM request",
+    );
+    const [pending] = a.listPendingRoomJoins();
+    assert.equal(pending?.roomPath, dmPath);
+    assert.equal(pending?.requesterId, b.peerId);
+
+    a.acceptRoomJoin(dmPath, b.peerId);
+    await requestPromise;
+  } finally {
+    await b.shutdown();
+    await a.shutdown();
+  }
+});
+
+void test("a rejected DM request throws, and never auto-approves the reciprocal reply", async () => {
+  const { a, b } = await makeConnectedPair(freshPort());
+
+  try {
+    const dmPath = dmRoomPath(a.peerId, b.peerId);
+
+    const aRequestPromise = a.requestDmAccess(b.peerId);
+    await waitFor(
+      () => b.listPendingRoomJoins().length === 1,
+      "B sees A's pending DM request",
+    );
+    b.rejectRoomJoin(dmPath, a.peerId, "not interested");
+    await assert.rejects(aRequestPromise, /was refused \(denied\)/);
+  } finally {
+    await b.shutdown();
+    await a.shutdown();
+  }
+});

--- a/src/test/room-join-admission.test.ts
+++ b/src/test/room-join-admission.test.ts
@@ -124,9 +124,10 @@ describe("handleRoomJoin (owner side)", () => {
     assert.equal(roomAfterReject?.members.includes(REQUESTER_ID), false);
   });
 
-  it("refuses a DM path outright, with no pending entry created", async () => {
+  it("refuses a DM path naming neither of its own device as a participant, with no pending entry created", async () => {
     const store = new MeshStore();
     await wireTestTransport(store);
+    // Neither "c"x64 nor "d"x64 is this store's own peerId, so this DM path names a conversation the store has no part in -- the dm-admission integration tests cover the genuinely-a-participant case end to end.
     const dmPath = `${deviceIdToHex(deviceIdFromHex("c".repeat(64)))}+${deviceIdToHex(deviceIdFromHex("d".repeat(64)))}`;
 
     const handler = store.roomVerbHandlers["room.join"];


### PR DESCRIPTION
Part of #48 (P3.4: admission -- room.join, room.invite, approval).

Fourth slice of P3.4, and the last of `handleRoomJoin`'s two admission branches (named room, done in #73; DM, this PR): section 6's own two-round consent flow. `handleRoomJoin` now branches on `parsed.kind` -- an owner-named room still needs its owner's approval exactly as before, and a DM path admits whichever of the two participants receives the request, unless this node already sent its own outbound `room.join` to the identical path, in which case the counterpart's reply auto-approves with no second human decision (A's own outbound request is already the consent, per the design's own reasoning).

`requestDmAccess(counterpart)` is the requester's own half: sends the ungated request, records having initiated it (`dmRequestsInitiatedByMe`), and persists whatever grant comes back. Kept outside the `CommsStore` interface, matching connection approval's own precedent, since it's wire-mesh-specific with nothing for `FileStore` to implement.

Genuinely different from #73's own testing situation, worth calling out: a real two-peer integration test actually works here. `dmRequestsInitiatedByMe` and the persisted room-token store are both purely local state legacy full-state-sync never replicates (unlike `this.rooms`), so two ordinarily connected peers stay in the "never DM'd before" state this flow exists for -- confirmed with a genuine two-peer test rather than routing around the same replication race #73 had to fall back to unit tests for.

Not yet integrated into `sendDm` itself -- that's P3.5's own job (message-sending doesn't use real wire verbs yet at all), so this PR builds the consent mechanism as its own callable entry point without yet wiring it into the send path.