### PR TITLE
feat(core): kick revokes a member's grant for real (P3.7)

### DIFF
--- a/src/core/identity-store.ts
+++ b/src/core/identity-store.ts
@@ -42,6 +42,8 @@ interface StoredIdentity {
   certificate: string;
   expiresAt: string;
   roomTokens?: Record<string, SerializedCapabilityToken>;
+  /** The token-id (base64) of each room:member grant this identity has itself issued to another device, keyed by "roomPath::memberDeviceHex" -- the bookkeeping a room owner needs to revoke a specific member's own grant later (kickFromRoom), distinct from roomTokens above (which holds tokens this identity BEARS, not ones it issued). */
+  issuedGrants?: Record<string, string>;
 }
 
 function isSerializedCapabilityToken(
@@ -73,10 +75,19 @@ function isStoredIdentity(value: unknown): value is StoredIdentity {
     typeof value.expiresAt !== "string"
   )
     return false;
-  if (!("roomTokens" in value)) return true;
-  const { roomTokens } = value;
-  if (typeof roomTokens !== "object" || roomTokens === null) return false;
-  return Object.values(roomTokens).every(isSerializedCapabilityToken);
+  if ("roomTokens" in value) {
+    const { roomTokens } = value;
+    if (typeof roomTokens !== "object" || roomTokens === null) return false;
+    if (!Object.values(roomTokens).every(isSerializedCapabilityToken))
+      return false;
+  }
+  if ("issuedGrants" in value) {
+    const { issuedGrants } = value;
+    if (typeof issuedGrants !== "object" || issuedGrants === null) return false;
+    if (!Object.values(issuedGrants).every((v) => typeof v === "string"))
+      return false;
+  }
+  return true;
 }
 
 function serializeToken(token: CapabilityToken): SerializedCapabilityToken {
@@ -310,4 +321,65 @@ export function deleteRoomToken(slot: IdentitySlot, roomPath: string): void {
     Object.entries(stored.roomTokens).filter(([path]) => path !== roomPath),
   );
   writeStoredIdentity(identityFile, { ...stored, roomTokens });
+}
+
+function issuedGrantKey(roomPath: string, memberDeviceHex: string): string {
+  return `${roomPath}::${memberDeviceHex}`;
+}
+
+/**
+ * The token-id this identity itself minted for the given member's room:member grant, or undefined if none is on record (the slot has never admitted this member, or the record predates this bookkeeping). A room owner consults this to revoke a specific member's own grant later -- a token-id, unlike the token itself, is never presented on the wire and so is never obtainable except from this identity's own memory of having minted it.
+ */
+export function loadIssuedRoomGrant(
+  slot: IdentitySlot,
+  roomPath: string,
+  memberDeviceHex: string,
+): Uint8Array<ArrayBuffer> | undefined {
+  const { identityFile } = slotPaths(slot);
+  const stored = readStoredIdentity(identityFile);
+  const encoded =
+    stored?.issuedGrants?.[issuedGrantKey(roomPath, memberDeviceHex)];
+  return encoded === undefined
+    ? undefined
+    : Uint8Array.from(Buffer.from(encoded, "base64"));
+}
+
+/**
+ * Records the token-id of a room:member grant this identity has just minted for memberDeviceHex in roomPath, surviving a restart the same way roomTokens does. Overwrites any earlier record for the same (roomPath, member) pair -- a fresh join/invite always supersedes the grant it replaces, so only the current token-id is ever worth revoking.
+ */
+export function saveIssuedRoomGrant(
+  slot: IdentitySlot,
+  roomPath: string,
+  memberDeviceHex: string,
+  tokenId: Uint8Array,
+): void {
+  const { identityFile } = slotPaths(slot);
+  const stored = readStoredIdentity(identityFile);
+  if (stored === undefined) {
+    throw new Error(
+      `no identity persisted for this slot yet -- call loadOrCreateIdentity first (${identityFile})`,
+    );
+  }
+  const issuedGrants = {
+    ...stored.issuedGrants,
+    [issuedGrantKey(roomPath, memberDeviceHex)]:
+      Buffer.from(tokenId).toString("base64"),
+  };
+  writeStoredIdentity(identityFile, { ...stored, issuedGrants });
+}
+
+/** Removes the recorded token-id for one (roomPath, member) grant, if any -- called once a kick has revoked it, so a later re-join mints and records a genuinely fresh one rather than leaving a stale entry alongside it. A no-op if none was recorded. */
+export function deleteIssuedRoomGrant(
+  slot: IdentitySlot,
+  roomPath: string,
+  memberDeviceHex: string,
+): void {
+  const { identityFile } = slotPaths(slot);
+  const stored = readStoredIdentity(identityFile);
+  if (stored?.issuedGrants === undefined) return;
+  const key = issuedGrantKey(roomPath, memberDeviceHex);
+  const issuedGrants = Object.fromEntries(
+    Object.entries(stored.issuedGrants).filter(([k]) => k !== key),
+  );
+  writeStoredIdentity(identityFile, { ...stored, issuedGrants });
 }

--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -37,8 +37,11 @@ import {
   deviceIdFromHex,
   deviceIdToHex,
 } from "wire-mesh-core/domain/device-id";
-import { mintCapabilityToken } from "wire-mesh-core/domain/tokens";
-import type { RevocationCheck } from "wire-mesh-core/domain/tokens";
+import {
+  mintCapabilityToken,
+  mintRevocationEntry,
+} from "wire-mesh-core/domain/tokens";
+import type { RevocationView } from "wire-mesh-core/domain/revocation-view";
 import type { IdentityPort } from "wire-mesh-core/ports/identity";
 import type { Clock } from "wire-mesh-core/ports/clock";
 import type {
@@ -54,13 +57,20 @@ import {
 import type {
   CapabilityToken,
   MessageRef,
+  RevocationEntry,
 } from "wire-mesh-core/generated/protocol";
 import type { RoomVerbHandler } from "./room-router.js";
 import {
   ROOM_MEMBER_CAPABILITY,
   verifyRoomToken,
 } from "./room-token-verification.js";
-import { loadRoomTokens, saveRoomToken } from "./identity-store.js";
+import {
+  deleteIssuedRoomGrant,
+  loadIssuedRoomGrant,
+  loadRoomTokens,
+  saveIssuedRoomGrant,
+  saveRoomToken,
+} from "./identity-store.js";
 import type { IdentitySlot } from "./identity-store.js";
 import { randomId } from "./random-id.js";
 import type { MeshMessage, MeshStatePatch, PeerInfo } from "./wire-protocol.js";
@@ -97,7 +107,7 @@ export interface MeshStoreIdentity {
   identity: IdentityPort;
   clock: Clock;
   slot: IdentitySlot;
-  revocation: RevocationCheck;
+  revocation: RevocationView;
 }
 
 /**
@@ -668,7 +678,18 @@ export class MeshStore implements CommsStore {
       onError: (error) => {
         this.onError?.(error);
       },
+      onRevocationAnnounce: (entry) => {
+        void this.handleRevocationAnnounce(entry);
+      },
     };
+  }
+
+  /** Verifies a gossiped revocation-entry and, if it verifies, records it in this store's own RevocationView -- future verifyRoomToken calls against this token's (token-id, issuer) pair fail with "revoked" from this point on. A failing entry is dropped silently: the same "hostile input produces a verdict, never a throw" contract verifyRevocationEntry itself already guarantees, so there is nothing further for a caller to react to. */
+  private async handleRevocationAnnounce(
+    entry: RevocationEntry,
+  ): Promise<void> {
+    const { identity, revocation } = this.requireIdentity();
+    await revocation.record(entry, { identity });
   }
 
   /** Append to a target agent's delivery queue, bounded oldest-first (#28). */
@@ -1601,12 +1622,13 @@ export class MeshStore implements CommsStore {
       };
     }
 
-    // Only identity/clock are needed here: the granted token belongs to the requester's own node, which persists it itself once it receives this response, not this store's own identity slot.
-    const { identity, clock } = this.requireIdentity();
+    // The granted token itself belongs to the requester's own node, which persists it itself once it receives this response -- but this identity slot must also remember the token-id it just issued (saveIssuedRoomGrant below), since revoking a specific member's grant later (kickFromRoom) has no other way to name which token-id to revoke: a token-id is never presented back on the wire, so a room owner's own memory of having minted it is the only record.
+    const { identity, clock, slot } = this.requireIdentity();
+    const tokenId = randomId();
     const verdict = await mintCapabilityToken({
       identity,
       clock,
-      tokenId: randomId(),
+      tokenId,
       bearer: deviceIdFromHex(handle.id),
       capability: "room:member",
       scope: { kind: "room", path: roomPath },
@@ -1616,6 +1638,7 @@ export class MeshStore implements CommsStore {
     if (!verdict.ok) {
       return { result: "error", code: "mint_failed" };
     }
+    saveIssuedRoomGrant(slot, roomPath, handle.id, tokenId);
 
     const room = this.rooms.get(roomPath);
     if (room !== undefined) {
@@ -2093,6 +2116,9 @@ export class MeshStore implements CommsStore {
     });
   }
 
+  /**
+   * Kicks targetId from roomId. Beyond the legacy CRDT membership removal (retired in P3.8 along with every other non-message broadcastPatch caller), this revokes the member's own room:member grant for real: mints a revocation-entry for the token-id this identity recorded when it admitted them (admitRoomJoin's own saveIssuedRoomGrant), records it in this store's own RevocationView immediately (so this identity's own future verifications see the kick without waiting on its own gossip), and announces it to every connected peer so each one's independent verification of the target's token -- not just this room's owner -- also starts failing as "revoked" from here on. Silently skips the revocation step (kick still happens; only the token-side enforcement doesn't) when no issued-grant record exists for this member, e.g. a grant predating this bookkeeping.
+   */
   async kickFromRoom(
     roomId: string,
     targetId: string,
@@ -2103,6 +2129,19 @@ export class MeshStore implements CommsStore {
       throw new CommsError(`Room ${roomId} not found`, "ROOM_NOT_FOUND");
     if (room.owner !== kickerId)
       throw new CommsError("Only the room owner can kick", "NOT_OWNER");
+
+    const { identity, clock, slot, revocation } = this.requireIdentity();
+    const tokenId = loadIssuedRoomGrant(slot, roomId, targetId);
+    if (tokenId !== undefined) {
+      const entry = await mintRevocationEntry({
+        identity,
+        tokenId,
+        revokedAt: clock.now(),
+      });
+      await revocation.record(entry, { identity });
+      await this.requireTransport().broadcastRevocation([entry]);
+      deleteIssuedRoomGrant(slot, roomId, targetId);
+    }
 
     this.bump(room);
     this.recordMemberOp(room, "member", "leave", targetId);

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -22,6 +22,7 @@ import type {
   CapabilityScope,
   CapabilityToken,
   ManageCommand,
+  RevocationEntry,
 } from "wire-mesh-core/generated/protocol";
 import type { ManageOutcome } from "wire-mesh-core/domain/mesh-session";
 
@@ -121,6 +122,11 @@ export interface TransportEvents {
    * We received a become_coordinator message — take over as coordinator.
    */
   onBecomeCoordinator(peerList: PeerInfo[]): void;
+
+  /**
+   * A peer announced one already-minted revocation-entry over an established session (management.cddl's revocation-announce, flattened to one call per entry). MeshStore should verify it and, if it verifies, record it in its own RevocationView -- a bearer's already-issued token stays valid to every peer that never received this until it does, per the design's own honest "detection with propagation delay" limit.
+   */
+  onRevocationAnnounce(entry: RevocationEntry): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -203,6 +209,11 @@ export interface MeshTransport {
    * Broadcast a wire message to all connected peer data connections.
    */
   broadcast(message: MeshMessage): Promise<void>;
+
+  /**
+   * Announces one or more already-minted revocation-entries to every connected peer session, best-effort (an unreachable peer misses it and learns of the revocation later, if ever -- the same honest gossip-propagation-delay limit every other broadcast in this codebase already accepts).
+   */
+  broadcastRevocation(entries: readonly RevocationEntry[]): Promise<void>;
 
   /**
    * Sends a real core/room manage-request to a specific member's own established session, returning its outcome (e.g. a room.join request's granted-token, or a room.send's delivery receipt) rather than swallowing it the way send() does for the legacy opaque-frame path. Resolves to a not_connected error outcome if no live session to that member exists, rather than throwing -- the caller (currently room-join, and P3.5's directed fan-out once it lands) decides how to react to an unreachable member.

--- a/src/core/wire-mesh-transport.ts
+++ b/src/core/wire-mesh-transport.ts
@@ -20,6 +20,7 @@ import type {
   CapabilityScope,
   CapabilityToken,
   ManageCommand,
+  RevocationEntry,
 } from "wire-mesh-core/generated/protocol";
 import type {
   Connection,
@@ -305,12 +306,22 @@ export class WireMeshTransport implements MeshTransport {
     })();
   }
 
-  /** Delegates the whole post-approval drain loop to roomRouter -- this transport no longer decodes or routes a MeshMessage itself, only hands the session off. */
+  /** Delegates the whole post-approval drain loop to roomRouter -- this transport no longer decodes or routes a MeshMessage itself, only hands the session off. Also starts this session's own independent revocationAnnouncements drain, since a gossiped revocation is not a manage-request and has no verb for roomRouter to dispatch. */
   private consumeIncoming(
     session: AcceptedMeshSession,
     handle: ConnectionHandle,
   ): void {
     this.roomRouter.drainSession(session, handle);
+    this.drainRevocationAnnouncements(session);
+  }
+
+  /** Reads every revocation-entry this session's peer announces, for as long as the session lives, handing each one to MeshStore via onRevocationAnnounce -- one call per entry, matching revocationAnnouncements' own per-entry flattening of a revocation-announce frame's entries array. */
+  private drainRevocationAnnouncements(session: AcceptedMeshSession): void {
+    void (async () => {
+      for await (const entry of session.revocationAnnouncements) {
+        this.events.onRevocationAnnounce(entry);
+      }
+    })();
   }
 
   private watchForDisconnect(
@@ -494,6 +505,16 @@ export class WireMeshTransport implements MeshTransport {
     await Promise.all(
       [...this.peerSessions.values()].map((session) =>
         session.sendManageRequest(command, FRAME_SCOPE).catch(() => undefined),
+      ),
+    );
+  }
+
+  async broadcastRevocation(
+    entries: readonly RevocationEntry[],
+  ): Promise<void> {
+    await Promise.all(
+      [...this.peerSessions.values()].map((session) =>
+        session.sendRevocationAnnounce(entries).catch(() => undefined),
       ),
     );
   }

--- a/src/test/become-coordinator-actual-port.integration.test.ts
+++ b/src/test/become-coordinator-actual-port.integration.test.ts
@@ -22,6 +22,7 @@ function noopEvents(): TransportEvents {
     onPeerList: () => undefined,
     onPeerJoined: () => undefined,
     onBecomeCoordinator: () => undefined,
+    onRevocationAnnounce: () => undefined,
   };
 }
 

--- a/src/test/listener-policy.integration.test.ts
+++ b/src/test/listener-policy.integration.test.ts
@@ -350,6 +350,7 @@ describe("listener policy", () => {
       onPeerList: () => undefined,
       onPeerJoined: () => undefined,
       onBecomeCoordinator: () => undefined,
+      onRevocationAnnounce: () => undefined,
     };
     const identity = generateIdentity();
     const transport = new WireMeshTransport(events, identity);

--- a/src/test/room-join-admission.test.ts
+++ b/src/test/room-join-admission.test.ts
@@ -212,6 +212,7 @@ describe("joinRoom (requester side, remote path)", () => {
       rejectConnection: async () => {},
       connectToRemote: async () => {},
       broadcast: async () => {},
+      broadcastRevocation: async () => {},
       sendRoomRequest: async (_memberId, command, scope) => {
         capturedRoomPath = scope.path;
         assert.deepEqual(command.params, { verb: "room.join" });

--- a/src/test/room-kick-revocation.integration.test.ts
+++ b/src/test/room-kick-revocation.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration test for kick-via-revocation (P3.7): kicking a member mints and announces a real revocation-entry for the token-id the owner recorded when it admitted them, so every connected peer that independently verifies that member's own room:member token -- not just the room's owner -- starts rejecting it, once the revocation-announce actually reaches them.
+ *
+ * Three real peers: owner (mints and later revokes A's grant), A (the member being kicked), and B (a fellow member who never talks to A about the kick directly -- B's own rejection of A's post-kick message is what proves the revocation-announce genuinely propagated over the wire, not merely that owner's own local view updated).
+ */
+
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import { MeshStore } from "../core/mesh-store.js";
+import type { DeliveryEvent } from "../core/types.js";
+import { waitFor, wireTestTransport } from "./test-transport.js";
+
+let nextPort = 21_110;
+function freshPort(): number {
+  nextPort += 1;
+  return nextPort;
+}
+
+async function makeRegisteredStore(
+  port: number,
+  name: string,
+): Promise<MeshStore> {
+  const store = new MeshStore(port);
+  await wireTestTransport(store);
+  await store.init();
+  await store.registerAgent({
+    name,
+    harness: "test",
+    cwd: `/test/${name}`,
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  return store;
+}
+
+/** Drives a real, admitted room.join round trip: sends the request, waits for the owner to see it pending, accepts it, and waits for the join to resolve. */
+async function joinAndAccept(
+  owner: MeshStore,
+  member: MeshStore,
+  roomId: string,
+): Promise<void> {
+  const joinPromise = member.joinRoom(roomId, member.peerId);
+  await waitFor(
+    () =>
+      owner
+        .listPendingRoomJoins()
+        .some((p) => p.roomPath === roomId && p.requesterId === member.peerId),
+    "owner to see member's pending join request",
+  );
+  owner.acceptRoomJoin(roomId, member.peerId);
+  await joinPromise;
+}
+
+void test("kicking a member revokes their room:member token for every peer, not just the owner", async () => {
+  const port = freshPort();
+  const owner = await makeRegisteredStore(port, "owner");
+  const memberA = await makeRegisteredStore(port, "member-a");
+  const memberB = await makeRegisteredStore(port, "member-b");
+
+  try {
+    // A's own fan-out to B below needs a real, direct A<->B peer connection, not merely each one's visibility of the coordinator (owner) -- so every pairwise agent-registry view must be settled, not just owner's own.
+    await waitFor(
+      () =>
+        owner.serialise().agents[memberA.peerId] !== undefined &&
+        owner.serialise().agents[memberB.peerId] !== undefined &&
+        memberA.serialise().agents[memberB.peerId] !== undefined &&
+        memberB.serialise().agents[memberA.peerId] !== undefined,
+      "owner and both members see one another",
+    );
+
+    const room = await owner.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.peerId,
+      description: "",
+    });
+    // B joins first: admitRoomJoin's own room.join response reports the room's CURRENT member list at admission time, so A's own local room record (constructed from A's later join response) only ever reflects B's membership if B is already admitted by the time A joins -- A's fan-out loop below reads its own stale-at-join-time member list, not a live view of the owner's.
+    await joinAndAccept(owner, memberB, room.id);
+    await joinAndAccept(owner, memberA, room.id);
+
+    const bDeliveries: DeliveryEvent[] = [];
+    memberB.onDelivery = (_agentId, event) => {
+      bDeliveries.push(event);
+    };
+
+    await memberA.sendRoomMessage(room.id, memberA.peerId, "before the kick");
+    await waitFor(
+      () =>
+        bDeliveries.some(
+          (event) =>
+            event.type === "room_message" &&
+            event.message.content === "before the kick",
+        ),
+      "B receives A's message while A is still a member",
+    );
+
+    await owner.kickFromRoom(room.id, memberA.peerId, owner.peerId);
+    // Settles the revocation-announce this kick just broadcast: B's own drain loop processes it asynchronously off the wire, with no observable side effect from outside B's own store to wait on affirmatively.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // sendRoomMessage (not used here) re-checks this store's own local CRDT room.members list, which the kick's own legacy room_upsert patch has by now also reached A through -- that would mask exactly what this test needs to isolate. sendRoomMessageDirected instead only ever consults A's own persisted bearer token (never revoked by kickFromRoom, which revokes the OWNER's own record of having issued it, not A's own copy), so it genuinely simulates a still-token-holding A trying to reach B directly -- the real scenario a token-side revocation exists to stop, independent of whatever A's own CRDT view happens to already know. B's own handleRoomSend rejects it with "unauthorized" (the announced revocation now verifies as revoked on B's own independent check), which sendRoomMessageDirected surfaces as a thrown error rather than swallowing it the way the fan-out path does.
+    await assert.rejects(
+      memberA.sendRoomMessageDirected(
+        room.id,
+        memberB.peerId,
+        "after the kick",
+      ),
+      /unauthorized/,
+      "B must reject a room.send sent under a token its owner already revoked",
+    );
+
+    assert.equal(
+      bDeliveries.some(
+        (event) =>
+          event.type === "room_message" &&
+          event.message.content === "after the kick",
+      ),
+      false,
+      "B must not have delivered a message sent under a revoked token",
+    );
+  } finally {
+    await memberB.shutdown();
+    await memberA.shutdown();
+    await owner.shutdown();
+  }
+});

--- a/src/test/room-router.test.ts
+++ b/src/test/room-router.test.ts
@@ -19,6 +19,7 @@ function fakeEvents(): TransportEvents {
     onPeerJoined: mock.fn(),
     onBecomeCoordinator: mock.fn(),
     onError: mock.fn(),
+    onRevocationAnnounce: mock.fn(),
   };
 }
 

--- a/src/test/room-send-retry-queue.test.ts
+++ b/src/test/room-send-retry-queue.test.ts
@@ -34,6 +34,7 @@ function fakeTransport(): {
     rejectConnection: async () => {},
     connectToRemote: async () => {},
     broadcast: async () => {},
+    broadcastRevocation: async () => {},
     sendRoomRequest: async (_memberId, command): Promise<ManageOutcome> => {
       attempts.push(command.params);
       if (!connected) {


### PR DESCRIPTION
## Summary
- Adds `onRevocationAnnounce`/`broadcastRevocation` to the transport layer, so a store can announce an already-minted revocation-entry to every connected peer and every peer independently records it into its own RevocationView.
- `admitRoomJoin` now persists the token-id of each grant it mints (keyed by room path + member device-id in the identity slot), since a token-id is never presented back on the wire and a room owner's own memory of having minted it is the only way to name which one to revoke later.
- `kickFromRoom` mints a revocation-entry for that token-id, records it locally, and announces it to every connected peer -- so a fellow member's own independent token verification (not just the owner's) starts rejecting the kicked member's messages, once the announcement reaches them.

Part of #48.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Full suite: 149/149 passing
- [x] `pnpm build`
- [x] Multi-process smoke test, 3 consecutive clean runs
- [x] Delivery-receipt suite, all 7 passing
- [x] New integration test confirmed RED without the implementation (typecheck fails without the interface additions) and GREEN with it