### PR TITLE
feat(core): revoke every member's grant when a room is destroyed (P3.8, part 3)

### DIFF
--- a/src/core/mesh-store.ts
+++ b/src/core/mesh-store.ts
@@ -2377,6 +2377,9 @@ export class MeshStore implements CommsStore {
     await this.broadcastPatch({ type: "room_upsert", room });
   }
 
+  /**
+   * Destroys roomId, revoking every member's own room:member grant for real first (P3.8) -- the same revocation machinery kickFromRoom already uses, since destroying a room out from under its members is exactly as much a membership revocation as kicking them individually would be, just for all of them at once. Room-existence notification (agent_upsert/room_delete) stays on the legacy broadcastPatch for now: replacing it needs the same broader informational-events redesign the rest of P3.8 already tracks as separate, larger work, not something this specific fix should improvise alone.
+   */
   async destroyRoom(roomId: string, agentId: string): Promise<void> {
     const room = this.rooms.get(roomId);
     if (!room)
@@ -2385,6 +2388,7 @@ export class MeshStore implements CommsStore {
       throw new CommsError("Only the room owner can destroy", "NOT_OWNER");
 
     for (const memberId of room.members) {
+      await this.revokeMemberGrant(roomId, memberId);
       const member = this.agents.get(memberId);
       if (member) {
         member.subscribedRooms = member.subscribedRooms.filter(

--- a/src/test/room-destroy-revocation.integration.test.ts
+++ b/src/test/room-destroy-revocation.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration test for destroy-via-revocation (P3.8): destroying a room revokes every member's own room:member grant for real, the same way kicking one member already does, so a fellow member's own independent token verification rejects a former member's message even after the room itself is gone from the owner's own bookkeeping.
+ */
+
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import { MeshStore } from "../core/mesh-store.js";
+import { waitFor, wireTestTransport } from "./test-transport.js";
+
+let nextPort = 21_410;
+function freshPort(): number {
+  nextPort += 1;
+  return nextPort;
+}
+
+async function makeRegisteredStore(
+  port: number,
+  name: string,
+): Promise<MeshStore> {
+  const store = new MeshStore(port);
+  await wireTestTransport(store);
+  await store.init();
+  await store.registerAgent({
+    name,
+    harness: "test",
+    cwd: `/test/${name}`,
+    pid: process.pid,
+    visibility: "visible",
+    tags: [],
+  });
+  return store;
+}
+
+async function joinAndAccept(
+  owner: MeshStore,
+  member: MeshStore,
+  roomId: string,
+): Promise<void> {
+  const joinPromise = member.joinRoom(roomId, member.peerId);
+  await waitFor(
+    () =>
+      owner
+        .listPendingRoomJoins()
+        .some((p) => p.roomPath === roomId && p.requesterId === member.peerId),
+    "owner to see member's pending join request",
+  );
+  owner.acceptRoomJoin(roomId, member.peerId);
+  await joinPromise;
+}
+
+void test("destroying a room revokes every member's own grant for every peer, not just the owner", async () => {
+  const port = freshPort();
+  const owner = await makeRegisteredStore(port, "owner");
+  const memberA = await makeRegisteredStore(port, "member-a");
+  const memberB = await makeRegisteredStore(port, "member-b");
+
+  try {
+    await waitFor(
+      () =>
+        owner.serialise().agents[memberA.peerId] !== undefined &&
+        owner.serialise().agents[memberB.peerId] !== undefined &&
+        memberA.serialise().agents[memberB.peerId] !== undefined &&
+        memberB.serialise().agents[memberA.peerId] !== undefined,
+      "owner and both members see one another",
+    );
+
+    const room = await owner.createRoom({
+      name: "general",
+      type: "public",
+      owner: owner.peerId,
+      description: "",
+    });
+    await joinAndAccept(owner, memberB, room.id);
+    await joinAndAccept(owner, memberA, room.id);
+
+    await owner.destroyRoom(room.id, owner.peerId);
+    // Settles the revocation-announce destroyRoom just broadcast for every member: B's own drain loop processes it asynchronously off the wire, with no observable side effect from outside B's own store to wait on affirmatively.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    await assert.rejects(
+      memberA.sendRoomMessageDirected(room.id, memberB.peerId, "still here?"),
+      /unauthorized/,
+      "B must reject a room.send sent under a grant the owner already revoked by destroying the room",
+    );
+  } finally {
+    await memberB.shutdown();
+    await memberA.shutdown();
+    await owner.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary
- `destroyRoom` now revokes every member's own room:member grant for real via the same `revokeMemberGrant` helper `kickFromRoom` uses, before its existing cleanup and `room_delete` broadcast. Destroying a room out from under its members is exactly as much a membership revocation as kicking them individually, just for all of them at once.
- Room-existence notification stays on the legacy broadcastPatch for now -- replacing it needs the same broader informational-events redesign already tracked separately in #48 (member_joined/member_left/member_status/room_delete all still ride it).

Part of #48.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Full suite: 153/153 passing
- [x] `pnpm build`
- [x] Multi-process smoke test, 3 consecutive clean runs
- [x] Delivery-receipt suite, all 7 passing
- [x] New integration test confirmed RED without the revocation call and GREEN with it