### PR TITLE
feat(core): expire an unanswered connect_request after a configurable timeout

### DIFF
--- a/src/core/wire-mesh-transport.ts
+++ b/src/core/wire-mesh-transport.ts
@@ -51,6 +51,13 @@ import {
 
 const COORDINATOR_HOST = "127.0.0.1";
 
+/** How long a connect_request may sit awaiting a human decision before this side gives up and rejects it automatically. Generous on purpose -- this bounds a human approval window, not a network timeout: 5 minutes covers a person genuinely being away from the terminal for a few minutes, while still guaranteeing every unanswered request eventually resolves instead of accumulating in pendingConnections indefinitely. */
+const PENDING_CONNECTION_TIMEOUT_MINUTES = 5;
+const SECONDS_PER_MINUTE = 60;
+const MS_PER_SECOND = 1000;
+const DEFAULT_PENDING_CONNECTION_TIMEOUT_MS =
+  PENDING_CONNECTION_TIMEOUT_MINUTES * SECONDS_PER_MINUTE * MS_PER_SECOND;
+
 /** This project's own namespaced domain (registrant "exadev.io", local name "agent-comms-v1"), matching namespaced-domain-id's "<registrant>/<local-name>" shape -- registry/core-domains.md's own recommended pattern for a third party. Exported for test use only: a security test simulating a hostile client that skips connect_request needs to construct a well-formed frame under the same domain/verb/scope this transport itself listens on, rather than duplicating these as separately-maintained magic strings that could silently drift from the real values. */
 export const DOMAIN = "exadev.io/agent-comms-v1";
 
@@ -93,6 +100,8 @@ interface PendingConnection {
   session: AcceptedMeshSession;
   /** Settles the Promise consumeQuarantined is blocked on for this connect_request -- the mechanism by which acceptConnection/rejectConnection resume a loop suspended mid-iteration, without ever needing to re-obtain (and so needing to reason about the identity of) a second iterator over the same session's incomingManageRequests. */
   resolve: (decision: ConnectionDecision) => void;
+  /** Auto-rejects this request after the configured pending-connection timeout if no human decision arrives first. Cleared by acceptConnection/rejectConnection/watchForDisconnect's own disconnect path, whichever settles the request first -- an entry is only ever removed from pendingConnections once, so this timer firing after another path already resolved it is structurally impossible, not merely guarded against. */
+  timeoutHandle: ReturnType<typeof setTimeout>;
 }
 
 interface TrackedListener {
@@ -154,10 +163,13 @@ export class WireMeshTransport implements MeshTransport {
   // -- The single consumer of every approved session's incomingManageRequests, once quarantine (if any) is past. Owns verb dispatch (the legacy opaque frame, plus whichever real core/room verbs later phases register handlers for) -- this transport itself no longer decodes or routes a MeshMessage at all beyond handing a session off here.
   private readonly roomRouter: RoomRouter;
 
+  private readonly pendingConnectionTimeoutMs: number;
+
   constructor(
     events: TransportEvents,
     identity: Readonly<PeerIdentity>,
     roomVerbHandlers?: Partial<Record<string, RoomVerbHandler>>,
+    pendingConnectionTimeoutMs: number = DEFAULT_PENDING_CONNECTION_TIMEOUT_MS,
   ) {
     this.events = events;
     this.wireTransport = createTlsTransport({
@@ -169,6 +181,7 @@ export class WireMeshTransport implements MeshTransport {
       events,
       ...(roomVerbHandlers !== undefined ? { handlers: roomVerbHandlers } : {}),
     });
+    this.pendingConnectionTimeoutMs = pendingConnectionTimeoutMs;
   }
 
   // -- Public getters --
@@ -269,7 +282,7 @@ export class WireMeshTransport implements MeshTransport {
           continue;
         }
         if (message.method === "connect_request") {
-          // Held open deliberately -- see this file's own header comment. Answered later by acceptConnection/rejectConnection, not here.
+          // Held open deliberately -- see this file's own header comment. Answered later by acceptConnection/rejectConnection, or by this.expirePendingConnection if neither happens within pendingConnectionTimeoutMs.
           const decision = await new Promise<ConnectionDecision>((resolve) => {
             this.pendingConnections.set(handle.id, {
               respond: request.respond,
@@ -279,6 +292,10 @@ export class WireMeshTransport implements MeshTransport {
               policy: handle.policy,
               session,
               resolve,
+              // unref()'d so a stray pending connection (this timer failing to be cleared through some path not yet covered) can never by itself keep the process alive for up to pendingConnectionTimeoutMs after everything else is done -- confirmed necessary directly: shutdown() originally cleared every pendingConnections entry without clearing its timer, and the whole test process hung for the full default timeout before exiting.
+              timeoutHandle: setTimeout(() => {
+                this.expirePendingConnection(handle.id);
+              }, this.pendingConnectionTimeoutMs).unref(),
             });
             this.events.onConnectionRequest(handle, {
               peerId: handle.id,
@@ -336,8 +353,12 @@ export class WireMeshTransport implements MeshTransport {
           if (wasTracked) this.peerSessions.delete(deviceIdHex);
           this.allSessions.delete(session);
           // A requester disconnecting before a human decides must unblock consumeQuarantined's own still-suspended loop iteration -- otherwise that promise, and the closure awaiting it, never settle.
-          this.pendingConnections.get(deviceIdHex)?.resolve("reject");
-          this.pendingConnections.delete(deviceIdHex);
+          const pending = this.pendingConnections.get(deviceIdHex);
+          if (pending !== undefined) {
+            clearTimeout(pending.timeoutHandle);
+            pending.resolve("reject");
+            this.pendingConnections.delete(deviceIdHex);
+          }
           // A no-op when this session was never a connectToPeer dial (e.g. the coordinator-client or an accepted connection) -- Set.delete on an absent key is always safe.
           this.dataDials.delete(deviceIdHex);
           if (wasTracked && !this.shutDown) {
@@ -347,6 +368,23 @@ export class WireMeshTransport implements MeshTransport {
         }
       }
     })();
+  }
+
+  /** Auto-rejects a connect_request that has sat unanswered past pendingConnectionTimeoutMs -- the same respond-then-resolve shape rejectConnection uses (a real error response, not a silent hang), since unlike watchForDisconnect's own cleanup path the requester's session is still very much alive and waiting to hear back. A no-op if the request was already settled by acceptConnection/rejectConnection/disconnect before this timer fired -- entries are deleted exactly once, by whichever path settles first. */
+  private expirePendingConnection(id: string): void {
+    const pending = this.pendingConnections.get(id);
+    if (pending === undefined) {
+      return;
+    }
+    this.pendingConnections.delete(id);
+    void pending
+      .respond({
+        result: "error",
+        code: "timeout",
+        message: "no human decision within the pending-connection timeout",
+      })
+      .catch(() => undefined);
+    pending.resolve("reject");
   }
 
   // -----------------------------------------------------------------------
@@ -579,6 +617,7 @@ export class WireMeshTransport implements MeshTransport {
     if (pending === undefined) {
       throw new Error(`No pending connection for handle ${handle.id}`);
     }
+    clearTimeout(pending.timeoutHandle);
     this.pendingConnections.delete(handle.id);
     await pending.respond({ result: "ok" });
     // Must happen before onIntroduction fires below: mesh-store's own handleIntroduction sends a reply on this exact handle synchronously as part of handling that event, which needs peerSessions already populated -- waiting for consumeQuarantined's own suspended loop to resume (via resolve() below) would race, since that only happens on a later microtask tick.
@@ -603,6 +642,7 @@ export class WireMeshTransport implements MeshTransport {
     if (pending === undefined) {
       throw new Error(`No pending connection for handle ${handle.id}`);
     }
+    clearTimeout(pending.timeoutHandle);
     this.pendingConnections.delete(handle.id);
     await pending.respond({
       result: "error",
@@ -668,6 +708,7 @@ export class WireMeshTransport implements MeshTransport {
     this.dataDials.clear();
 
     for (const pending of this.pendingConnections.values()) {
+      clearTimeout(pending.timeoutHandle);
       await pending
         .respond({ result: "error", code: "shutting_down" })
         .catch(() => undefined);

--- a/src/test/approval.integration.test.ts
+++ b/src/test/approval.integration.test.ts
@@ -275,6 +275,77 @@ describe("connection approval", () => {
     }
   });
 
+  void test("connect_request expires and is auto-rejected if left unanswered past the configured timeout", async () => {
+    const portA = await uniquePort();
+    const portB = await uniquePort();
+    const SHORT_PENDING_CONNECTION_TIMEOUT_MS = 300;
+
+    const storeA = new MeshStore(portA);
+    wireTestTransport(storeA, undefined, SHORT_PENDING_CONNECTION_TIMEOUT_MS);
+    const storeB = new MeshStore(portB);
+    wireTestTransport(storeB);
+    try {
+      const receivedRequests: Extract<
+        DeliveryEvent,
+        { type: "connection_request" }
+      >[] = [];
+      storeA.onDelivery = (_id, event) => {
+        if (event.type === "connection_request") {
+          receivedRequests.push(event);
+        }
+      };
+      await storeA.init();
+      await storeA.registerAgent({
+        name: "coordinator",
+        harness: "test",
+        cwd: "/test/a",
+        pid: process.pid,
+        visibility: "visible",
+        tags: [],
+      });
+
+      await sleep(100);
+
+      await storeB.startDataServerOnly();
+      await storeB.registerAgent({
+        name: "connector",
+        harness: "test",
+        cwd: "/test/b",
+        pid: process.pid,
+        visibility: "visible",
+        tags: [],
+      });
+
+      storeB.connectToRemote("127.0.0.1", portA);
+
+      await waitFor(
+        () => receivedRequests.length === 1,
+        "coordinator receives the connection request",
+      );
+      const request = receivedRequests[0];
+      assert.ok(request?.connectionId);
+
+      // No accept/reject call at all -- wait past the configured timeout with the request left untouched.
+      await sleep(SHORT_PENDING_CONNECTION_TIMEOUT_MS + 500);
+
+      // The strongest available proof the entry actually expired (not merely "still pending, not yet an agent," which would be equally true before any decision): acceptConnection on an expired request must fail exactly the way it fails for any other unknown handle, since expirePendingConnection has already deleted it.
+      await assert.rejects(
+        () => storeA.acceptConnection(request.connectionId),
+        /No pending connection/,
+        "An expired connect_request should no longer be acceptable",
+      );
+
+      const agentsA = await storeA.listAgents(storeA.peerId);
+      assert.ok(
+        !agentsA.some((a) => a.id === storeB.peerId),
+        "An expired, auto-rejected peer should not appear in agent list",
+      );
+    } finally {
+      await storeB.shutdown();
+      await storeA.shutdown();
+    }
+  });
+
   void test("mesh_pending lists pending connections", async () => {
     const portA = await uniquePort();
     const portB = await uniquePort();

--- a/src/test/test-transport.ts
+++ b/src/test/test-transport.ts
@@ -13,10 +13,11 @@ import { toIdentityPort } from "../core/wire-mesh-identity.js";
 import { nanoid } from "../core/nanoid.js";
 import type { MeshStore } from "../core/mesh-store.js";
 
-/** Wires store onto a fresh WireMeshTransport and a persisted identity slot, returning the slot so a test can inspect (or reuse) the persisted room tokens directly via loadRoomTokens(). Defaults to a throwaway temp-dir slot per call -- pass an explicit slot when a test needs the same identity to survive across more than one wireTestTransport call (e.g. simulating a restart). */
+/** Wires store onto a fresh WireMeshTransport and a persisted identity slot, returning the slot so a test can inspect (or reuse) the persisted room tokens directly via loadRoomTokens(). Defaults to a throwaway temp-dir slot per call -- pass an explicit slot when a test needs the same identity to survive across more than one wireTestTransport call (e.g. simulating a restart). pendingConnectionTimeoutMs overrides WireMeshTransport's own default 5-minute connect_request expiry -- a test proving that expiry behaviour needs it far shorter than any real approval window. */
 export async function wireTestTransport(
   store: MeshStore,
   slot?: Readonly<IdentitySlot>,
+  pendingConnectionTimeoutMs?: number,
 ): Promise<IdentitySlot> {
   const resolvedSlot: IdentitySlot = slot ?? {
     harness: "test",
@@ -27,7 +28,14 @@ export async function wireTestTransport(
   // Every real bridge sets peerId to deviceIdToHex(identity.deviceId) before wiring the transport (createBridgeMesh) -- WireMeshTransport's own session bookkeeping is keyed by device-id, so a peer's advertised ID and the identity the other side actually authenticates the connection against must be the same value, or introduction/state-sync never recognises the peer as itself.
   store.peerId = deviceIdToHex(Uint8Array.from(identity.deviceId));
   store.setTransport(
-    new WireMeshTransport(store.events, identity, store.roomVerbHandlers),
+    new WireMeshTransport(
+      store.events,
+      identity,
+      store.roomVerbHandlers,
+      ...(pendingConnectionTimeoutMs !== undefined
+        ? [pendingConnectionTimeoutMs]
+        : []),
+    ),
   );
   store.setIdentity({
     identity: await toIdentityPort(identity),


### PR DESCRIPTION
A pending approval held in pendingConnections previously had no cap on how long it could sit awaiting a human decision -- only a requester disconnecting first ever cleaned it up. A per-request timer now auto-rejects it with a real error response (not a silent hang) after pendingConnectionTimeoutMs, defaulting to 5 minutes; cleared wherever the request is otherwise settled (acceptConnection, rejectConnection, a disconnect, or shutdown) so a resolved request's timer never fires again.

Confirmed directly while building this: shutdown() cleared every pendingConnections entry without clearing its timer, and the whole test process hung for the full 5-minute default before exiting -- fixed there, and every timer is also unref()'d so a future cleanup gap of the same shape can never again keep the process alive on its own.

Part of ExaDev/wire-mesh#81.